### PR TITLE
Proofs

### DIFF
--- a/benches/proofs.rs
+++ b/benches/proofs.rs
@@ -1,0 +1,56 @@
+#![feature(test)]
+
+extern crate test;
+
+use test::Bencher;
+use merk::test_utils::*;
+use merk::tree::*;
+
+#[bench]
+fn proof_1m_1_memonly(b: &mut Bencher) {
+    proof_memonly(b, 1_000_000, 1);
+}
+
+#[bench]
+fn proof_1m_4_memonly(b: &mut Bencher) {
+    proof_memonly(b, 1_000_000, 4);
+}
+
+#[bench]
+fn proof_1m_16_memonly(b: &mut Bencher) {
+    proof_memonly(b, 1_000_000, 16);
+}
+
+#[bench]
+fn proof_1m_64_memonly(b: &mut Bencher) {
+    proof_memonly(b, 1_000_000, 64);
+}
+
+#[bench]
+fn proof_1m_256_memonly(b: &mut Bencher) {
+    proof_memonly(b, 1_000_000, 256);
+}
+
+#[bench]
+fn proof_1m_1024_memonly(b: &mut Bencher) {
+    proof_memonly(b, 1_000_000, 1024);
+}
+
+fn proof_memonly(b: &mut Bencher, tree_size: u64, proof_size: u64) {
+    let batch_size = 10_000;
+    let seed = 59421441857 * proof_size;
+    let mut tree = make_tree_rand(tree_size, batch_size, seed);
+    let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+    let mut i = 0;
+    b.iter(|| {
+        let batch = make_batch_rand(proof_size, seed + i);
+        let mut keys = Vec::with_capacity(proof_size as usize);
+        for (key, _) in batch {
+            keys.push(key);
+        }
+        let (proof, absence) = walker.create_proof(keys.as_slice())
+            .expect("create_proof errored");
+        i = (i + 1) % (tree_size / batch_size);
+    });
+}

--- a/benches/proofs.rs
+++ b/benches/proofs.rs
@@ -5,15 +5,11 @@ extern crate test;
 use test::Bencher;
 use merk::test_utils::*;
 use merk::tree::*;
+use merk::proofs::*;
 
 #[bench]
 fn proof_1m_1_memonly(b: &mut Bencher) {
     proof_memonly(b, 1_000_000, 1);
-}
-
-#[bench]
-fn proof_1m_4_memonly(b: &mut Bencher) {
-    proof_memonly(b, 1_000_000, 4);
 }
 
 #[bench]
@@ -22,18 +18,23 @@ fn proof_1m_16_memonly(b: &mut Bencher) {
 }
 
 #[bench]
-fn proof_1m_64_memonly(b: &mut Bencher) {
-    proof_memonly(b, 1_000_000, 64);
-}
-
-#[bench]
 fn proof_1m_256_memonly(b: &mut Bencher) {
     proof_memonly(b, 1_000_000, 256);
 }
 
 #[bench]
-fn proof_1m_1024_memonly(b: &mut Bencher) {
-    proof_memonly(b, 1_000_000, 1024);
+fn verify_present_1m_1_memonly(b: &mut Bencher) {
+    verify_present_bench(b, 1_000_000, 1);
+}
+
+#[bench]
+fn verify_present_1m_16_memonly(b: &mut Bencher) {
+    verify_present_bench(b, 1_000_000, 16);
+}
+
+#[bench]
+fn verify_present_1m_256_memonly(b: &mut Bencher) {
+    verify_present_bench(b, 1_000_000, 256);
 }
 
 fn proof_memonly(b: &mut Bencher, tree_size: u64, proof_size: u64) {
@@ -52,5 +53,35 @@ fn proof_memonly(b: &mut Bencher, tree_size: u64, proof_size: u64) {
         let (proof, absence) = walker.create_proof(keys.as_slice())
             .expect("create_proof errored");
         i = (i + 1) % (tree_size / batch_size);
+    });
+}
+
+fn verify_present_bench(b: &mut Bencher, tree_size: u64, proof_size: u64) {
+    let batch_size = 10_000;
+    let seed = 59421441857 * proof_size;
+    let mut tree = make_tree_rand(tree_size, batch_size, seed);
+    let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+    let mut keys_and_proofs = vec![];
+    for i in 0..10 {
+        let batch = make_batch_rand(proof_size, seed + i);
+        let mut keys = Vec::with_capacity(proof_size as usize);
+        for (key, _) in batch {
+            keys.push(key);
+        }
+        let (proof, absence) = walker.create_proof(keys.as_slice())
+            .expect("create_proof errored");
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        
+        keys_and_proofs.push((keys, bytes));
+    }
+
+    let mut i = 0;
+    b.iter(|| {
+        let (keys, bytes) = &keys_and_proofs[i];
+        verify(bytes.as_slice(), keys.as_slice(), [0; 20]);
+        i = (i + 1) % keys_and_proofs.len();
     });
 }

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -2,7 +2,7 @@
 
 **Matt Bell ([@mappum](https://twitter.com/mappum))** • [Nomic Hodlings, Inc.](https://nomic.io)
 
-v0.0.1 - *August 27, 2019*
+v0.0.3 - *August 28, 2019*
 
 ## Introduction
 
@@ -135,12 +135,12 @@ We can efficiently encode these proofs by encoding each operator as follows:
 ```
 Push(Hash(hash)) => 0x01 <20-byte hash>
 Push(KVHash(hash)) => 0x02 <20-byte hash>
-Push(KV(key, value)) => 0x03 <1-byte key length> <n-byte key> <4-byte value length> <n-byte value>
+Push(KV(key, value)) => 0x03 <1-byte key length> <n-byte key> <2-byte value length> <n-byte value>
 Parent => 0x10
 Child => 0x11
 ```
 
-This results in a compact binary representation, with a very small space overhead (roughly 2 bytes per node in the proof, plus 5 bytes per key/value pair).
+This results in a compact binary representation, with a very small space overhead (roughly 2 bytes per node in the proof (1 byte for the `Push` operator type flag, and 1 byte for a `Parent` or `Child` operator), plus 3 bytes per key/value pair (1 byte for the key length, and 2 bytes for the value length)).
 
 #### Efficient Proofs for Ranges of Keys
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod tree;
 mod merk;
 pub mod test_utils;
 pub mod owner;
+pub mod proofs;
 
 pub use error::{Error, Result};
 pub use self::merk::Merk;

--- a/src/proofs/encoding.rs
+++ b/src/proofs/encoding.rs
@@ -1,0 +1,182 @@
+use std::convert::TryInto;
+
+use super::{Op, Node};
+use crate::tree::HASH_LENGTH;
+use crate::error::Result;
+
+// TODO: Encode, Decode traits
+
+impl Op {
+    pub fn encode_into(&self, output: &mut Vec<u8>) {
+        match self {
+            Op::Push(Node::Hash(hash)) => {
+                output.push(0x01);
+                output.extend(hash);
+            },
+            Op::Push(Node::KVHash(kv_hash)) => {
+                output.push(0x02);
+                output.extend(kv_hash);
+            },
+            Op::Push(Node::KV(key, value)) => {
+                output.push(0x03);
+                output.push(key.len().try_into().unwrap());
+                output.extend(key);
+                output.push((value.len() & 0xff).try_into().unwrap());
+                output.push((value.len() >> 8).try_into().unwrap());
+                output.extend(value);
+            },
+            Op::Parent => output.push(0x10),
+            Op::Child => output.push(0x11)
+        }
+    }
+
+    pub fn encoding_length(&self) -> usize {
+        match self {
+            Op::Push(Node::Hash(_)) => 1 + HASH_LENGTH,
+            Op::Push(Node::KVHash(_)) => 1 + HASH_LENGTH,
+            Op::Push(Node::KV(key, value)) => 4 + key.len() + value.len(),
+            Op::Parent => 1,
+            Op::Child => 1
+        }
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        Ok(match bytes[0] {
+            0x01 => {
+                let mut hash = [0; HASH_LENGTH];
+                hash.copy_from_slice(&bytes[1..HASH_LENGTH + 1]);
+                Op::Push(Node::Hash(hash))
+            },
+            0x02 => {
+                let mut hash = [0; HASH_LENGTH];
+                hash.copy_from_slice(&bytes[1..HASH_LENGTH + 1]);
+                Op::Push(Node::KVHash(hash))
+            },
+            0x03 => {
+                let mut offset = 1;
+
+                let key_len = bytes[offset] as usize;
+                offset += 1;
+                let key = bytes[offset..offset + key_len].to_vec();
+                offset += key_len;
+
+                let value_len =
+                    bytes[offset] as usize
+                    + ((bytes[offset + 1] as usize) << 8);
+                offset += 2;
+                let value = bytes[offset..offset + value_len].to_vec();
+                // offset += value_len;
+
+                Op::Push(Node::KV(key, value))
+            },
+            0x10 => Op::Parent,
+            0x11 => Op::Child,
+            _ => bail!("Proof has unexpected value")
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::{Op, Node};
+    use crate::tree::HASH_LENGTH;
+
+    #[test]
+    fn encode_push_hash() {
+        let op = Op::Push(Node::Hash([123; HASH_LENGTH]));
+        assert_eq!(op.encoding_length(), 1 + HASH_LENGTH);
+
+        let mut bytes = vec![];
+        op.encode_into(&mut bytes);
+        assert_eq!(bytes, vec![0x01, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123]);
+    }
+
+    #[test]
+    fn encode_push_kvhash() {
+        let op = Op::Push(Node::KVHash([123; HASH_LENGTH]));
+        assert_eq!(op.encoding_length(), 1 + HASH_LENGTH);
+
+        let mut bytes = vec![];
+        op.encode_into(&mut bytes);
+        assert_eq!(bytes, vec![0x02, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123]);
+    }
+
+    #[test]
+    fn encode_push_kv() {
+        let op = Op::Push(Node::KV(vec![1, 2, 3], vec![4, 5, 6]));
+        assert_eq!(op.encoding_length(), 10);
+
+        let mut bytes = vec![];
+        op.encode_into(&mut bytes);
+        assert_eq!(bytes, vec![0x03, 3, 1, 2, 3, 3, 0, 4, 5, 6]);
+    }
+
+    #[test]
+    fn encode_parent() {
+        let op = Op::Parent;
+        assert_eq!(op.encoding_length(), 1);
+
+        let mut bytes = vec![];
+        op.encode_into(&mut bytes);
+        assert_eq!(bytes, vec![0x10]);
+    }
+
+    #[test]
+    fn encode_child() {
+        let op = Op::Child;
+        assert_eq!(op.encoding_length(), 1);
+
+        let mut bytes = vec![];
+        op.encode_into(&mut bytes);
+        assert_eq!(bytes, vec![0x11]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn encode_push_kv_long_key() {
+        let op = Op::Push(Node::KV(vec![123; 300], vec![4, 5, 6]));
+        let mut bytes = vec![];
+        op.encode_into(&mut bytes);
+    }
+
+    #[test]
+    fn decode_push_hash() {
+        let bytes = [0x01, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123];
+        let op = Op::decode(&bytes[..]).expect("decode failed");
+        assert_eq!(op, Op::Push(Node::Hash([123; HASH_LENGTH])));
+    }
+
+    #[test]
+    fn decode_push_kvhash() {
+        let bytes = [0x02, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123];
+        let op = Op::decode(&bytes[..]).expect("decode failed");
+        assert_eq!(op, Op::Push(Node::KVHash([123; HASH_LENGTH])));
+    }
+
+    #[test]
+    fn decode_push_kv() {
+        let bytes = [0x03, 3, 1, 2, 3, 3, 0, 4, 5, 6];
+        let op = Op::decode(&bytes[..]).expect("decode failed");
+        assert_eq!(op, Op::Push(Node::KV(vec![1, 2, 3], vec![4, 5, 6])));
+    }
+
+    #[test]
+    fn decode_parent() {
+        let bytes = [0x10];
+        let op = Op::decode(&bytes[..]).expect("decode failed");
+        assert_eq!(op, Op::Parent);
+    }
+
+    #[test]
+    fn decode_child() {
+        let bytes = [0x11];
+        let op = Op::decode(&bytes[..]).expect("decode failed");
+        assert_eq!(op, Op::Child);
+    }
+
+    #[test]
+    fn decode_unknown() {
+        let bytes = [0x88];
+        assert!(Op::decode(&bytes[..]).is_err());
+    }
+}

--- a/src/proofs/encoding.rs
+++ b/src/proofs/encoding.rs
@@ -76,6 +76,16 @@ impl Op {
     }
 }
 
+pub fn encode_into<'a, T: Iterator<Item=&'a Op>>(ops: T, output: &mut Vec<u8>) {
+    for op in ops {
+        op.encode_into(output);
+    }
+}
+
+pub fn encoding_length<'a, T: Iterator<Item=&'a Op>>(ops: T) -> usize {
+    ops.map(|op| op.encoding_length()).sum()
+}
+
 #[cfg(test)]
 mod test {
     use super::super::{Op, Node};

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -387,6 +387,10 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (false, false));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        assert_eq!(bytes, vec![3, 1, 1, 1, 0, 1, 3, 1, 2, 1, 0, 2, 16, 3, 1, 3, 1, 0, 3, 3, 1, 4, 1, 0, 4, 16, 17, 2, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 16, 1, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 17]);
     }
 }
 

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -12,7 +12,7 @@ pub enum Op {
     Child
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Node {
     Hash(Hash),
     KVHash(Hash),

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -3,6 +3,7 @@ mod encoding;
 use std::collections::LinkedList;
 use crate::error::Result;
 use crate::tree::{Tree, Link, RefWalker, Hash, Fetch};
+pub use encoding::{encode_into, encoding_length};
 
 #[derive(Debug, PartialEq)]
 pub enum Op {

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -163,6 +163,7 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Push(Node::Hash([7; 20]))));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
     }
 
     #[test]
@@ -181,6 +182,7 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Push(Node::Hash([7; 20]))));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
     }
 
     #[test]
@@ -199,6 +201,7 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Push(Node::Hash([7; 20]))));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
     }
 
     #[test]
@@ -217,6 +220,7 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
     }
 
     #[test]
@@ -235,6 +239,7 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
     }
 
     #[test]
@@ -253,6 +258,7 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (false, true));
     }
 
     #[test]
@@ -271,6 +277,7 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
     }
 
     #[test]
@@ -377,6 +384,7 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Push(Node::Hash([9; 20]))));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
     }
 }
 

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -1,0 +1,143 @@
+use std::collections::LinkedList;
+use crate::error::Result;
+use crate::tree::{Tree, Link, RefWalker, Hash, Fetch};
+
+#[derive(Debug)]
+pub enum Op {
+    Push(Node),
+    Parent,
+    Child
+}
+
+#[derive(Debug)]
+pub enum Node {
+    Hash(Hash),
+    KVHash(Hash),
+    KV(Vec<u8>, Vec<u8>)
+}
+
+impl Link {
+    fn to_hash_node(&self) -> Node {
+        let hash = match self {
+            Link::Modified { .. } => {
+                panic!("Cannot convert Link::Modified to proof hash node");
+            },
+            Link::Pruned { hash, .. } => hash,
+            Link::Stored { hash, .. } => hash
+        };
+        Node::Hash(hash.clone())
+    }
+}
+
+impl<'a, S> RefWalker<'a, S>
+    where S: Fetch + Sized + Send + Clone
+{
+    fn to_kv_node(&self) -> Node {
+        Node::KV(
+            self.tree().key().to_vec(),
+            self.tree().value().to_vec()
+        )
+    }
+
+    fn to_kvhash_node(&self) -> Node {
+        Node::KVHash(self.tree().kv_hash().clone())
+    }
+
+    pub(crate) fn create_proof(
+        &mut self,
+        keys: &[Vec<u8>],
+    ) -> Result<(
+        LinkedList<Op>,
+        (bool, bool)
+    )> {
+        let search = keys.binary_search_by(
+            |key| key.as_slice().cmp(self.tree().key())
+        );
+
+        let (left_keys, right_keys) = match search {
+            Ok(index) => (&keys[..index], &keys[index+1..]),
+            Err(index) => (&keys[..index], &keys[index..])
+        };
+
+        let (mut proof, left_absence) =
+            self.create_child_proof(true, left_keys)?;
+        let (mut right_proof, right_absence) =
+            self.create_child_proof(false, right_keys)?;
+
+        let (has_left, has_right) = (
+            !proof.is_empty(),
+            !right_proof.is_empty()
+        );
+
+        proof.push_back(match search {
+            Ok(index) => Op::Push(self.to_kv_node()),
+            Err(index) => {
+                if left_absence.1 || right_absence.0 {
+                    Op::Push(self.to_kv_node())
+                } else {
+                    Op::Push(self.to_kvhash_node())
+                }
+            }
+        });
+
+        if has_left {
+            proof.push_back(Op::Parent);
+        }
+
+        if has_right {
+            proof.append(&mut right_proof);
+            proof.push_back(Op::Child);
+        }
+
+        Ok((
+            proof,
+            (left_absence.0, right_absence.1)
+        ))
+    }
+
+    fn create_child_proof(
+        &mut self,
+        left: bool,
+        keys: &[Vec<u8>]
+    ) -> Result<(
+        LinkedList<Op>,
+        (bool, bool)
+    )> {
+        Ok(if !keys.is_empty() {
+            if let Some(mut child) = self.walk(left)? {
+                child.create_proof(keys)?
+            } else {
+                (LinkedList::new(), (true, true))
+            }
+        } else if let Some(link) = self.tree().link(left) {
+            let mut proof = LinkedList::new();
+            proof.push_back(Op::Push(link.to_hash_node()));
+            (proof, (false, false))
+        } else {
+            (LinkedList::new(), (false, false))
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_utils::{make_tree_seq, seq_key};
+    use crate::tree::{PanicSource, RefWalker};
+
+    #[test]
+    fn simple_proof() {
+        let mut tree = make_tree_seq(20);
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let (proof, absence) = walker.create_proof(vec![
+            seq_key(4),
+            seq_key(5),
+            seq_key(10),
+            seq_key(100)
+        ].as_slice()).expect("create_proof errored");
+
+        println!("{:#?}", proof);
+    }
+}
+

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -43,7 +43,7 @@ impl<'a, S> RefWalker<'a, S>
         Node::KVHash(self.tree().kv_hash().clone())
     }
 
-    pub(crate) fn create_proof(
+    pub fn create_proof(
         &mut self,
         keys: &[Vec<u8>],
     ) -> Result<(

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -1,4 +1,5 @@
 mod encoding;
+mod verify;
 
 use std::collections::LinkedList;
 use crate::error::Result;

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -25,7 +25,7 @@ impl Link {
             Link::Pruned { hash, .. } => hash,
             Link::Stored { hash, .. } => hash
         };
-        Node::Hash(hash.clone())
+        Node::Hash(*hash)
     }
 }
 
@@ -40,7 +40,7 @@ impl<'a, S> RefWalker<'a, S>
     }
 
     fn to_kvhash_node(&self) -> Node {
-        Node::KVHash(self.tree().kv_hash().clone())
+        Node::KVHash(*self.tree().kv_hash())
     }
 
     pub fn create_proof(
@@ -70,8 +70,8 @@ impl<'a, S> RefWalker<'a, S>
         );
 
         proof.push_back(match search {
-            Ok(index) => Op::Push(self.to_kv_node()),
-            Err(index) => {
+            Ok(_) => Op::Push(self.to_kv_node()),
+            Err(_) => {
                 if left_absence.1 || right_absence.0 {
                     Op::Push(self.to_kv_node())
                 } else {

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -1,3 +1,5 @@
+mod encoding;
+
 use std::collections::LinkedList;
 use crate::error::Result;
 use crate::tree::{Tree, Link, RefWalker, Hash, Fetch};
@@ -122,7 +124,6 @@ impl<'a, S> RefWalker<'a, S>
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_utils::{make_tree_seq, seq_key};
     use crate::tree::{PanicSource, RefWalker};
 
     fn make_3_node_tree() -> Tree {

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -5,6 +5,7 @@ use std::collections::LinkedList;
 use crate::error::Result;
 use crate::tree::{Tree, Link, RefWalker, Hash, Fetch};
 pub use encoding::{encode_into, encoding_length};
+pub use verify::verify;
 
 #[derive(Debug, PartialEq)]
 pub enum Op {

--- a/src/proofs/verify.rs
+++ b/src/proofs/verify.rs
@@ -1,0 +1,188 @@
+use super::{Op, Node};
+use crate::tree::{NULL_HASH, Hash, kv_hash, node_hash};
+use crate::error::Result;
+
+struct Tree {
+    node: Node,
+    left: Option<Box<Tree>>,
+    right: Option<Box<Tree>>
+}
+
+impl From<Node> for Tree {
+    fn from(node: Node) -> Self {
+        Tree { node, left: None, right: None }
+    }
+}
+
+impl Tree {
+    fn child(&self, left: bool) -> Option<&Tree> {
+        if left {
+            self.left.as_ref()
+        } else {
+            self.right.as_ref()
+        }
+    }
+
+    fn child_mut(&mut self, left: bool) -> Option<&mut Tree> {
+        if left {
+            self.left.as_mut()
+        } else {
+            self.right.as_mut()
+        }
+    }
+
+    fn attach(&mut self, left: bool, child: Tree) {
+        if self.child(left).is_some() {
+            bail!("Tried to attach to left child, but it is already Some");
+        }
+
+        let child = child.into_hash();
+        let boxed = Box::new(child);
+        *self.child_mut(left) = Some(boxed);
+    }
+
+    #[inline]
+    fn hash(&self) -> &Hash {
+        match self.node {
+            Node::Hash(hash) => &hash,
+            _ => unreachable!("Expected Node::Hash")
+        }
+    }
+
+    #[inline]
+    fn child_hash(&self, left: bool) -> Option<&Hash> {
+        self.child(left)
+            .map_or(NULL_HASH, |c| c.hash())
+    }
+
+    fn into_hash(self) -> Tree {
+        let to_hash_node = |kv_hash| {
+            let hash = node_hash(
+                &kv_hash,
+                self.child_hash(true),
+                self.child_hash(false)
+            );
+            Node::Hash(hash)
+        };
+
+        match self.node {
+            Node::Hash(hash) => self,
+            Node::KVHash(kv_hash) => to_hash_node(kv_hash),
+            Node::KV(key, value) => {
+                let kv_hash = kv_hash(key.as_slice(), value.as_slice());
+                to_hash_node(kv_hash)
+            }
+        }
+    }
+}
+
+pub fn verify(
+    bytes: &[u8],
+    keys: &[Vec<u8>],
+    expected_hash: Hash
+) -> Result<Vec<Option<Vec<u8>>>> {
+    // TODO: enforce a maximum proof size
+
+    let mut stack = Vec::with_capacity(32);
+    let mut output = Vec::with_capacity(keys.len());
+
+    let mut key_index = 0;
+    let mut last_push = None;
+
+    let try_pop = || {
+        match stack.pop() {
+            None => bail!("Stack underflow"),
+            Some(tree) => tree
+        }
+    };
+
+    let mut offset = 0;
+    loop {
+        if bytes.len() <= offset {
+            break;
+        }
+
+        let op = Op::decode(&bytes[offset..])?;
+        offset += op.encoding_length();
+
+        match op {
+            Op::Parent => {
+                let (parent, child) = (try_pop()?, try_pop()?);
+                parent.attach(true, child);
+                stack.push(parent);
+            },
+            Op::Child => {
+                let (child, parent) = (try_pop()?, try_pop()?);
+                parent.attach(false, child);
+                stack.push(parent);
+            },
+            Op::Push(node) => {
+                let node_clone = node.clone();
+                let tree = node.into::<Tree>();
+                stack.push(tree);
+
+                if let Node::KV(key, value) = node_clone {
+                    // keys should always be increasing
+                    if let Some(Node::KV(last_key, _)) = last_push {
+                        if key <= last_key {
+                            bail!("Incorrect key ordering");
+                        }
+                    }
+
+                    loop {
+                        if key == keys[key_index] {
+                            // KV for queried key
+                            output.push(Some(value.clone()));
+                        } else if key > keys[key_index] {
+                            match last_push {
+                                None | Node::KV(_, _) => {
+                                    // previous push was a boundary (global edge or lower key),
+                                    // so this is a valid absence proof
+                                    output.push(None);
+                                },
+                                // proof is incorrect since it skipped queried keys
+                                _ => bail!("Proof incorrectly formed");
+                            }
+                        } else {
+                            break;
+                        }
+
+                        key_index += 1;
+                    }
+                }
+
+                last_push = Some(node_clone);
+            }
+        }
+    }
+
+    // absence proofs for right edge
+    if key_index < keys.len() {
+        if let Some(Node::KV(_, _)) = last_push {
+            for _ in 0..(keys.len() - key_index) {
+                output.push(None);
+            }
+        } else {
+            bail!("Proof incorrectly formed");
+        }
+    } else {
+        debug_assert_eq!(keys.len(), output.len());
+    }
+
+    if stack.len() != 1 {
+        bail!("Expected proof to result in exactly one stack item");
+    }
+
+    let root = stack[0];
+    if root.hash() != expected_hash {
+        bail!("Proof did not match expected hash");
+    }
+
+    Ok(output)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+}
+

--- a/src/proofs/verify.rs
+++ b/src/proofs/verify.rs
@@ -15,7 +15,7 @@ impl From<Node> for Tree {
 }
 
 impl Tree {
-    fn child(&self, left: bool) -> Option<&Tree> {
+    fn child(&self, left: bool) -> Option<&Box<Tree>> {
         if left {
             self.left.as_ref()
         } else {
@@ -23,15 +23,15 @@ impl Tree {
         }
     }
 
-    fn child_mut(&mut self, left: bool) -> Option<&mut Tree> {
+    fn child_mut(&mut self, left: bool) -> &mut Option<Box<Tree>> {
         if left {
-            self.left.as_mut()
+            &mut self.left
         } else {
-            self.right.as_mut()
+            &mut self.right
         }
     }
 
-    fn attach(&mut self, left: bool, child: Tree) {
+    fn attach(&mut self, left: bool, child: Tree) -> Result<()> {
         if self.child(left).is_some() {
             bail!("Tried to attach to left child, but it is already Some");
         }
@@ -39,40 +39,41 @@ impl Tree {
         let child = child.into_hash();
         let boxed = Box::new(child);
         *self.child_mut(left) = Some(boxed);
+        Ok(())
     }
 
     #[inline]
-    fn hash(&self) -> &Hash {
+    fn hash(&self) -> Hash {
         match self.node {
-            Node::Hash(hash) => &hash,
+            Node::Hash(hash) => hash,
             _ => unreachable!("Expected Node::Hash")
         }
     }
 
     #[inline]
-    fn child_hash(&self, left: bool) -> Option<&Hash> {
+    fn child_hash(&self, left: bool) -> Hash {
         self.child(left)
             .map_or(NULL_HASH, |c| c.hash())
     }
 
     fn into_hash(self) -> Tree {
-        let to_hash_node = |kv_hash| {
+        fn to_hash_node(tree: &Tree, kv_hash: Hash) -> Node {
             let hash = node_hash(
                 &kv_hash,
-                self.child_hash(true),
-                self.child_hash(false)
+                &tree.child_hash(true),
+                &tree.child_hash(false)
             );
             Node::Hash(hash)
-        };
+        }
 
-        match self.node {
-            Node::Hash(hash) => self,
-            Node::KVHash(kv_hash) => to_hash_node(kv_hash),
+        match &self.node {
+            Node::Hash(hash) => self.node,
+            Node::KVHash(kv_hash) => to_hash_node(&self, *kv_hash),
             Node::KV(key, value) => {
                 let kv_hash = kv_hash(key.as_slice(), value.as_slice());
-                to_hash_node(kv_hash)
+                to_hash_node(&self, kv_hash)
             }
-        }
+        }.into()
     }
 }
 
@@ -83,16 +84,16 @@ pub fn verify(
 ) -> Result<Vec<Option<Vec<u8>>>> {
     // TODO: enforce a maximum proof size
 
-    let mut stack = Vec::with_capacity(32);
+    let mut stack: Vec<Tree> = Vec::with_capacity(32);
     let mut output = Vec::with_capacity(keys.len());
 
     let mut key_index = 0;
     let mut last_push = None;
 
-    let try_pop = || {
+    fn try_pop(stack: &mut Vec<Tree>) -> Result<Tree> {
         match stack.pop() {
             None => bail!("Stack underflow"),
-            Some(tree) => tree
+            Some(tree) => Ok(tree)
         }
     };
 
@@ -107,44 +108,50 @@ pub fn verify(
 
         match op {
             Op::Parent => {
-                let (parent, child) = (try_pop()?, try_pop()?);
-                parent.attach(true, child);
+                let (mut parent, child) = (
+                    try_pop(&mut stack)?,
+                    try_pop(&mut stack)?
+                );
+                parent.attach(true, child)?;
                 stack.push(parent);
             },
             Op::Child => {
-                let (child, parent) = (try_pop()?, try_pop()?);
-                parent.attach(false, child);
+                let (child, mut parent) = (
+                    try_pop(&mut stack)?,
+                    try_pop(&mut stack)?
+                );
+                parent.attach(false, child)?;
                 stack.push(parent);
             },
             Op::Push(node) => {
                 let node_clone = node.clone();
-                let tree = node.into::<Tree>();
+                let tree: Tree = node.into();
                 stack.push(tree);
 
-                if let Node::KV(key, value) = node_clone {
+                if let Node::KV(key, value) = &node_clone {
                     // keys should always be increasing
-                    if let Some(Node::KV(last_key, _)) = last_push {
-                        if key <= last_key {
+                    if let Some(Node::KV(last_key, _)) = &last_push {
+                        if key <= &last_key {
                             bail!("Incorrect key ordering");
                         }
                     }
 
                     loop {
-                        if key == keys[key_index] {
+                        if key_index >= keys.len() || key < &keys[key_index] {
+                            break;
+                        } else if key == &keys[key_index] {
                             // KV for queried key
                             output.push(Some(value.clone()));
-                        } else if key > keys[key_index] {
-                            match last_push {
-                                None | Node::KV(_, _) => {
+                        } else if key > &keys[key_index] {
+                            match &last_push {
+                                None | Some(Node::KV(_, _)) => {
                                     // previous push was a boundary (global edge or lower key),
                                     // so this is a valid absence proof
                                     output.push(None);
                                 },
                                 // proof is incorrect since it skipped queried keys
-                                _ => bail!("Proof incorrectly formed");
+                                _ => bail!("Proof incorrectly formed")
                             }
-                        } else {
-                            break;
                         }
 
                         key_index += 1;
@@ -173,9 +180,13 @@ pub fn verify(
         bail!("Expected proof to result in exactly one stack item");
     }
 
-    let root = stack[0];
-    if root.hash() != expected_hash {
-        bail!("Proof did not match expected hash");
+    let root = stack.pop().unwrap();
+    let hash = root.into_hash().hash();
+    if hash != expected_hash {
+        bail!(
+            "Proof did not match expected hash\n\tExpected: {:?}\n\tActual: {:?}",
+            expected_hash, hash
+        );
     }
 
     Ok(output)
@@ -184,5 +195,98 @@ pub fn verify(
 #[cfg(test)]
 mod test {
     use super::*;
+    use super::super::*;
+    use crate::tree::{NoopCommit, RefWalker, PanicSource};
+    use crate::tree;
+
+    fn make_3_node_tree() -> tree::Tree {
+        let mut tree = tree::Tree::new(vec![5], vec![5])
+            .attach(true, Some(tree::Tree::new(vec![3], vec![3])))
+            .attach(false, Some(tree::Tree::new(vec![7], vec![7])));
+        tree.commit(&mut NoopCommit {})
+            .expect("commit failed");
+        tree
+    }
+
+    fn verify_test(keys: Vec<Vec<u8>>, expected_result: Vec<Option<Vec<u8>>>) {
+        let mut tree = make_3_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let (proof, _) = walker.create_proof(keys.as_slice())
+            .expect("failed to create proof");
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+
+        let expected_hash = [65, 23, 96, 10, 165, 42, 240, 100, 206, 125, 192, 81, 44, 89, 119, 39, 35, 215, 211, 24];
+        let result = verify(bytes.as_slice(), keys.as_slice(), expected_hash)
+            .expect("verify failed");
+        assert_eq!(result, expected_result);
+    }
+
+    #[test]
+    fn root_verify() {
+        verify_test(vec![ vec![5] ], vec![ Some(vec![5]) ]);
+    }
+
+    #[test]
+    fn single_verify() {
+        verify_test(vec![ vec![3] ], vec![ Some(vec![3]) ]);
+    }
+
+    #[test]
+    fn double_verify() {
+       verify_test(
+           vec![ vec![3], vec![5] ],
+           vec![ Some(vec![3]), Some(vec![5]) ]
+        );
+    }
+
+    #[test]
+    fn double_verify_2() {
+       verify_test(
+           vec![ vec![3], vec![7] ],
+           vec![ Some(vec![3]), Some(vec![7]) ]
+        );
+    }
+
+    #[test]
+    fn triple_verify() {
+       verify_test(
+           vec![ vec![3], vec![5], vec![7] ],
+           vec![ Some(vec![3]), Some(vec![5]), Some(vec![7]) ]
+        );
+    }
+
+    #[test]
+    fn left_edge_absence_verify() {
+       verify_test(
+           vec![ vec![2] ],
+           vec![ None ]
+        );
+    }
+
+    #[test]
+    fn right_edge_absence_verify() {
+       verify_test(
+           vec![ vec![8] ],
+           vec![ None ]
+        );
+    }
+
+    #[test]
+    fn inner_absence_verify() {
+       verify_test(
+           vec![ vec![6] ],
+           vec![ None ]
+        );
+    }
+
+    #[test]
+    fn absent_and_present_verify() {
+       verify_test(
+           vec![ vec![5], vec![6] ],
+           vec![ Some(vec![5]), None ]
+        );
+    }
 }
 

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -69,18 +69,19 @@ pub fn apply_to_memonly(maybe_tree: Option<Tree>, batch: &Batch) -> Option<Tree>
         })
 }
 
-pub fn put_entry(n: u64) -> BatchEntry {
+pub fn seq_key(n: u64) -> Vec<u8> {
     let mut key = vec![0; 0];
     key.write_u64::<BigEndian>(n)
         .expect("writing to key failed");
-    (key, Op::Put(vec![123; 60]))
+    key
+}
+
+pub fn put_entry(n: u64) -> BatchEntry {
+    (seq_key(n), Op::Put(vec![123; 60]))
 }
 
 pub fn del_entry(n: u64) -> BatchEntry {
-    let mut key = vec![0; 0];
-    key.write_u64::<BigEndian>(n)
-        .expect("writing to key failed");
-    (key, Op::Delete)
+    (seq_key(n), Op::Delete)
 }
 
 pub fn make_batch_seq(range: Range<u64>) -> Vec<BatchEntry> {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -15,7 +15,7 @@ use super::error::Result;
 pub use commit::{Commit, NoopCommit};
 use kv::KV;
 pub use link::Link;
-pub use hash::{Hash, node_hash, NULL_HASH, HASH_LENGTH};
+pub use hash::{Hash, kv_hash, node_hash, NULL_HASH, HASH_LENGTH};
 pub use ops::{Batch, BatchEntry, PanicSource, Op};
 
 struct TreeInner {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -15,7 +15,7 @@ use super::error::Result;
 pub use commit::{Commit, NoopCommit};
 use kv::KV;
 pub use link::Link;
-pub use hash::{Hash, node_hash, NULL_HASH};
+pub use hash::{Hash, node_hash, NULL_HASH, HASH_LENGTH};
 pub use ops::{Batch, BatchEntry, PanicSource, Op};
 
 struct TreeInner {

--- a/src/tree/walk/mod.rs
+++ b/src/tree/walk/mod.rs
@@ -1,6 +1,8 @@
 mod fetch;
+mod ref_walker;
 
 pub use fetch::Fetch;
+pub use ref_walker::RefWalker;
 use crate::error::Result;
 use super::{Tree, Link};
 use crate::owner::Owner;

--- a/src/tree/walk/ref_walker.rs
+++ b/src/tree/walk/ref_walker.rs
@@ -51,10 +51,6 @@ impl<'a, S> RefWalker<'a, S>
         }
     }
 
-    fn wrap(&self, tree: &'a mut Tree) -> Self {
-        RefWalker::new(tree, self.clone_source())
-    }
-
     pub fn clone_source(&self) -> S {
         self.source.clone()
     }

--- a/src/tree/walk/ref_walker.rs
+++ b/src/tree/walk/ref_walker.rs
@@ -1,0 +1,61 @@
+use crate::error::Result;
+use super::Fetch;
+use super::super::{Tree, Link};
+
+pub struct RefWalker<'a, S>
+    where S: Fetch + Sized + Clone + Send
+{
+    tree: &'a Tree,
+    source: S
+}
+
+impl<'a, S> RefWalker<'a, S>
+    where S: Fetch + Sized + Clone + Send
+{
+    pub fn new(tree: &'a mut Tree, source: S) -> Self {
+        Walker { tree, source }
+    }
+
+    pub fn tree(&self) -> &'a Tree {
+        self.tree
+    }
+
+    pub fn walk(&mut self, left: bool) -> Result<Option<Self>> {
+        let link = match self.tree.link(left) {
+            None => return Ok(None),
+            Some(link) => link
+        };
+
+        match link {
+            Link::Modified { .. } => panic!("Cannot traverse Link::Modified"),
+            Link::Stored { .. } => {},
+            Link::Pruned { .. } => {
+                self.tree.load(left, &self.source)?;
+            }
+        }
+
+        Ok(self.tree.child_mut(left))
+    }
+
+    pub fn walk_expect(&self, left: bool) -> Result<Self> {
+
+    }
+
+    pub fn tree(&self) -> &Tree {
+        &self.tree
+    }
+
+    fn wrap(&self, tree: Tree) -> Self {
+        Walker::new(tree, self.source.clone())
+    }
+
+    pub fn clone_source(&self) -> S {
+        self.source.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    
+}
+


### PR DESCRIPTION
I'm working on simple proof generation/verification in this branch. This will be query proofs rather than state-sync chunk proofs (which will come in a later update).

This will support:
- Querying N keys
- Proving keys/values, or absence of a key
- Creating query workers, which can generate proofs for queries concurrently (for the last committed tree state), even while changes are being made to the tree