### PR TITLE
Add function to return root of a proof that can later be verified via a signing scheme.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,3 +34,4 @@ pub use tree::{Batch, BatchEntry, Hash, Op, PanicSource, HASH_LENGTH};
 pub use proofs::query::verify_query;
 
 pub use proofs::query::verify;
+pub use proofs::query::execute_proof;

--- a/src/proofs/query/map.rs
+++ b/src/proofs/query/map.rs
@@ -78,7 +78,7 @@ impl Map {
         Ok(entry)
     }
 
-    pub fn all(&self) -> Iter<'_, K, V> {
+    pub fn all(&self) -> Iter<'_, Vec<u8>, (bool, Vec<u8>)> {
         self.entries.iter()
     }
 

--- a/src/proofs/query/map.rs
+++ b/src/proofs/query/map.rs
@@ -4,6 +4,7 @@ use failure::{bail, ensure, format_err};
 use std::collections::btree_map;
 use std::collections::BTreeMap;
 use std::ops::{Bound, RangeBounds};
+use std::collections::btree_map::Iter;
 
 /// `MapBuilder` allows a consumer to construct a `Map` by inserting the nodes
 /// contained in a proof, in key-order.
@@ -75,6 +76,10 @@ impl Map {
             .transpose()?
             .map(|(_, value)| value);
         Ok(entry)
+    }
+
+    pub fn all(&self) -> Iter<'_, K, V> {
+        self.entries.iter()
     }
 
     /// Returns an iterator over all (key, value) entries in the requested range

--- a/src/proofs/query/mod.rs
+++ b/src/proofs/query/mod.rs
@@ -355,6 +355,16 @@ pub fn verify(bytes: &[u8], expected_hash: Hash) -> Result<Map> {
     Ok(map_builder.build())
 }
 
+pub fn execute_proof(bytes: &[u8]) -> Result<(Hash,Map)> {
+    let ops = Decoder::new(bytes);
+    let mut map_builder = MapBuilder::new();
+
+    let root = execute(ops, true, |node| map_builder.insert(node))?;
+
+    Ok((root.hash(), map_builder.build()))
+}
+
+
 /// Verifies the encoded proof with the given query and expected hash.
 ///
 /// Every key in `keys` is checked to either have a key/value pair in the proof,


### PR DESCRIPTION
Using verify query on light clients would require them to be supplied with the expected root hash, in addition to the proof, keys and signature. Since the proof already contains the root_hash, and any other root hash wouldn't match for the signature, it would be optimal not to send it.

The change requested adds a new function that executes the proof and returns the root hash and the elements. That root hash can then be verified by a signature scheme.