### PR TITLE
Clear TODOs from kv_hash function and node_hash

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,8 @@ pub enum Error {
     HashMismatch([u8; 32], [u8; 32]),
     #[error("Index OoB Error: {0}")]
     IndexOutOfBounds(String),
+    #[error("Integer conversion error: {0}")]
+    IntegerConversionError(#[from] std::num::TryFromIntError),
     #[error(transparent)]
     IO(#[from] std::io::Error),
     #[error("Tried to delete non-existent key {0:?}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(map_first_last)]
 #![feature(trivial_bounds)]
 
 #[global_allocator]

--- a/src/merk/chunks.rs
+++ b/src/merk/chunks.rs
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn generate_and_verify_chunks() {
+    fn generate_and_verify_chunks() -> Result<()> {
         let mut merk = TempMerk::new().unwrap();
         let batch = make_batch_seq(1..10_000);
         merk.apply(batch.as_slice(), &[]).unwrap();
@@ -191,14 +191,15 @@ mod tests {
         let ops = Decoder::new(chunk.as_slice());
         let (trunk, height) = verify_trunk(ops).unwrap();
         assert_eq!(height, 14);
-        assert_eq!(trunk.hash(), merk.root_hash());
+        assert_eq!(trunk.hash()?, merk.root_hash());
 
         assert_eq!(trunk.layer(7).count(), 128);
 
         for (chunk, node) in chunks.zip(trunk.layer(height / 2)) {
             let ops = Decoder::new(chunk.as_slice());
-            verify_leaf(ops, node.hash()).unwrap();
+            verify_leaf(ops, node.hash()?).unwrap();
         }
+        Ok(())
     }
 
     #[test]

--- a/src/merk/chunks.rs
+++ b/src/merk/chunks.rs
@@ -96,7 +96,7 @@ impl<'a> ChunkProducer<'a> {
             return Ok(self.trunk.encode()?);
         }
 
-        assert!(!(self.index >= self.len()), "Called next_chunk after end");
+        assert!(self.index < self.len(), "Called next_chunk after end");
 
         let end_key = self.chunk_boundaries.get(self.index - 1);
         let end_key_slice = end_key.as_ref().map(|k| k.as_slice());
@@ -208,7 +208,7 @@ mod tests {
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let path = format!("chunks_from_reopen_{}.db", time);
+        let path = format!("chunks_from_reopen_{time}.db");
 
         let original_chunks = {
             let mut merk = Merk::open(&path).unwrap();

--- a/src/merk/mod.rs
+++ b/src/merk/mod.rs
@@ -8,12 +8,12 @@ use std::collections::LinkedList;
 use std::path::{Path, PathBuf};
 
 use rocksdb::{checkpoint::Checkpoint, ColumnFamilyDescriptor, WriteBatch};
-use rocksdb::{DBAccess, DB};
+use rocksdb::DB;
 
 use crate::error::{Error, Result};
 use crate::proofs::{encode_into, query::QueryItem, Query};
 use crate::tree::{
-    Batch, Commit, Fetch, GetResult, Hash, Link, Op, RefWalker, Tree, Walker, NULL_HASH,
+    Batch, Commit, Fetch, GetResult, Hash, Op, RefWalker, Tree, Walker, NULL_HASH,
 };
 
 pub use self::snapshot::Snapshot;
@@ -365,14 +365,14 @@ impl Merk {
         MerkSource { db: &self.db }
     }
 
-    fn use_tree<T>(&self, mut f: impl FnOnce(Option<&Tree>) -> T) -> T {
+    fn use_tree<T>(&self, f: impl FnOnce(Option<&Tree>) -> T) -> T {
         let tree = self.tree.take();
         let res = f(tree.as_ref());
         self.tree.set(tree);
         res
     }
 
-    fn use_tree_mut<T>(&self, mut f: impl FnOnce(Option<&mut Tree>) -> T) -> T {
+    fn use_tree_mut<T>(&self, f: impl FnOnce(Option<&mut Tree>) -> T) -> T {
         let mut tree = self.tree.take();
         let res = f(tree.as_mut());
         self.tree.set(tree);

--- a/src/merk/mod.rs
+++ b/src/merk/mod.rs
@@ -547,7 +547,7 @@ mod test {
         let mut merk = TempMerk::open(path).expect("failed to open merk");
 
         for i in 0..(tree_size / batch_size) {
-            println!("i:{}", i);
+            println!("i:{i}");
             let batch = make_batch_rand(batch_size, i);
             merk.apply(&batch, &[]).expect("apply failed");
         }
@@ -633,15 +633,21 @@ mod test {
     fn reopen() {
         fn collect(mut node: RefWalker<MerkSource>, nodes: &mut Vec<Vec<u8>>) {
             nodes.push(node.tree().encode());
-            node.walk(true).unwrap().map(|c| collect(c, nodes));
-            node.walk(false).unwrap().map(|c| collect(c, nodes));
+            node.walk(true)
+                .unwrap()
+                .into_iter()
+                .for_each(|c| collect(c, nodes));
+            node.walk(false)
+                .unwrap()
+                .into_iter()
+                .for_each(|c| collect(c, nodes));
         }
 
         let time = std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let path = format!("merk_reopen_{}.db", time);
+        let path = format!("merk_reopen_{time}.db");
 
         let original_nodes = {
             let mut merk = Merk::open(&path).unwrap();
@@ -678,7 +684,7 @@ mod test {
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let path = format!("merk_reopen_{}.db", time);
+        let path = format!("merk_reopen_{time}.db");
 
         let original_nodes = {
             let mut merk = Merk::open(&path).unwrap();

--- a/src/merk/mod.rs
+++ b/src/merk/mod.rs
@@ -215,7 +215,7 @@ impl Merk {
         tmp.destroy()?;
 
         // TODO: split up batch
-        let mut node = Tree::new(vec![], vec![]);
+        let mut node = Tree::new(vec![], vec![])?;
         let batch: Vec<_> = self
             .db
             .iterator(IteratorMode::Start)

--- a/src/merk/mod.rs
+++ b/src/merk/mod.rs
@@ -7,14 +7,12 @@ use std::cmp::Ordering;
 use std::collections::LinkedList;
 use std::path::{Path, PathBuf};
 
-use rocksdb::{checkpoint::Checkpoint, ColumnFamilyDescriptor, WriteBatch};
 use rocksdb::DB;
+use rocksdb::{checkpoint::Checkpoint, ColumnFamilyDescriptor, WriteBatch};
 
 use crate::error::{Error, Result};
 use crate::proofs::{encode_into, query::QueryItem, Query};
-use crate::tree::{
-    Batch, Commit, Fetch, GetResult, Hash, Op, RefWalker, Tree, Walker, NULL_HASH,
-};
+use crate::tree::{Batch, Commit, Fetch, GetResult, Hash, Op, RefWalker, Tree, Walker, NULL_HASH};
 
 pub use self::snapshot::Snapshot;
 

--- a/src/merk/restore.rs
+++ b/src/merk/restore.rs
@@ -107,13 +107,15 @@ impl Restorer {
         let mut batch = WriteBatch::default();
 
         tree.visit_refs(&mut |proof_node| {
-            let (key, value) = match &proof_node.node {
-                Node::KV(key, value) => (key, value),
+            let (key, mut node) = match &proof_node.node {
+                // TODO: encode tree node without cloning key/value
+                Node::KV(key, value) => match Tree::new(key.clone(), value.clone()) {
+                    Ok(node) => (key, node),
+                    Err(_) => return
+                },
                 _ => return,
             };
 
-            // TODO: encode tree node without cloning key/value
-            let mut node = Tree::new(key.clone(), value.clone());
             *node.slot_mut(true) = proof_node.left.as_ref().map(Child::as_link);
             *node.slot_mut(false) = proof_node.right.as_ref().map(Child::as_link);
 
@@ -132,8 +134,8 @@ impl Restorer {
     fn process_trunk(&mut self, ops: Decoder) -> Result<usize> {
         let (trunk, height) = verify_trunk(ops)?;
 
-        if trunk.hash() != self.expected_root_hash {
-            return Err(Error::HashMismatch(self.expected_root_hash, trunk.hash()));
+        if trunk.hash()? != self.expected_root_hash {
+            return Err(Error::HashMismatch(self.expected_root_hash, trunk.hash()?));
         }
 
         let root_key = trunk.key().to_vec();
@@ -145,7 +147,7 @@ impl Restorer {
             let leaf_hashes = trunk
                 .layer(trunk_height)
                 .map(|node| node.hash())
-                .collect::<Vec<Hash>>()
+                .collect::<Result<Vec<_>>>()?
                 .into_iter()
                 .peekable();
             self.leaf_hashes = Some(leaf_hashes);

--- a/src/merk/restore.rs
+++ b/src/merk/restore.rs
@@ -111,7 +111,7 @@ impl Restorer {
                 // TODO: encode tree node without cloning key/value
                 Node::KV(key, value) => match Tree::new(key.clone(), value.clone()) {
                     Ok(node) => (key, node),
-                    Err(_) => return
+                    Err(_) => return,
                 },
                 _ => return,
             };

--- a/src/merk/snapshot.rs
+++ b/src/merk/snapshot.rs
@@ -2,8 +2,8 @@ use std::cell::Cell;
 
 use crate::{
     proofs::{query::QueryItem, Query},
-    tree::{Fetch, GetResult, RefWalker, Tree, NULL_HASH},
-    Hash, MerkSource, Result,
+    tree::{Fetch, RefWalker, Tree, NULL_HASH},
+    Hash, Result,
 };
 
 pub struct Snapshot<'a> {
@@ -63,14 +63,14 @@ impl<'a> Snapshot<'a> {
         SnapshotSource(&self.db)
     }
 
-    fn use_tree<T>(&self, mut f: impl FnOnce(Option<&Tree>) -> T) -> T {
+    fn use_tree<T>(&self, f: impl FnOnce(Option<&Tree>) -> T) -> T {
         let tree = self.tree.take();
         let res = f(tree.as_ref());
         self.tree.set(tree);
         res
     }
 
-    fn use_tree_mut<T>(&self, mut f: impl FnOnce(Option<&mut Tree>) -> T) -> T {
+    fn use_tree_mut<T>(&self, f: impl FnOnce(Option<&mut Tree>) -> T) -> T {
         let mut tree = self.tree.take();
         let res = f(tree.as_mut());
         self.tree.set(tree);

--- a/src/merk/snapshot.rs
+++ b/src/merk/snapshot.rs
@@ -22,7 +22,7 @@ impl<'a> Snapshot<'a> {
     pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         self.use_tree(|maybe_tree| {
             maybe_tree
-                .and_then(|tree| super::get(&tree, self.source(), key).transpose())
+                .and_then(|tree| super::get(tree, self.source(), key).transpose())
                 .transpose()
         })
     }

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -60,6 +60,25 @@ impl<T> Owner<T> {
         return_value
     }
 
+    /// Takes temporary ownership of the contained value by passing it to `f`.
+    /// The function must return a value of the same type (the same value, or a
+    /// new value to take its place).
+    ///
+    /// Like `own`, but with a fallible operation.
+    ///
+    /// # Example
+    /// ```
+    /// # use merk::owner::Owner;
+    /// let mut owner = Owner::new(123);
+    /// let converted = owner.own_fallible(|n| u32::try_from(n))?;
+    /// ```
+    pub fn own_fallible<E, F: FnOnce(T) -> Result<T, E>>(&mut self, f: F) -> Result<(), E> {
+        let old_value = unwrap(self.inner.take());
+        let new_value = f(old_value)?;
+        self.inner = Some(new_value);
+        Ok(())
+    }
+
     /// Sheds the `Owner` container and returns the value it contained.
     pub fn into_inner(mut self) -> T {
         unwrap(self.inner.take())

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -69,6 +69,7 @@ impl<T> Owner<T> {
     /// # Example
     /// ```
     /// # use merk::owner::Owner;
+    /// # use std::convert::TryFrom;
     /// let mut owner = Owner::new(123);
     /// let converted = owner.own_fallible(|n| u32::try_from(n))?;
     /// ```

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -71,7 +71,7 @@ impl<T> Owner<T> {
     /// # use merk::owner::Owner;
     /// # use std::convert::TryFrom;
     /// let mut owner = Owner::new(123);
-    /// let converted = owner.own_fallible(|n| u32::try_from(n))?;
+    /// let converted = owner.own_fallible(|n| u32::try_from(n));
     /// ```
     pub fn own_fallible<E, F: FnOnce(T) -> Result<T, E>>(&mut self, f: F) -> Result<(), E> {
         let old_value = unwrap(self.inner.take());

--- a/src/proofs/chunk.rs
+++ b/src/proofs/chunk.rs
@@ -303,7 +303,7 @@ mod tests {
         assert!(!has_more);
 
         println!("{:?}", &proof);
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
 
         let counts = count_node_types(trunk);
         assert_eq!(counts.hash, 0);
@@ -318,7 +318,7 @@ mod tests {
 
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
         assert!(has_more);
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
 
         let counts = count_node_types(trunk);
         // are these formulas correct for all values of `MIN_TRUNK_HEIGHT`? 🤔
@@ -339,7 +339,7 @@ mod tests {
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
         assert!(!has_more);
 
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
         let counts = count_node_types(trunk);
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 1);
@@ -359,7 +359,7 @@ mod tests {
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
         assert!(!has_more);
 
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
         let counts = count_node_types(trunk);
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 2);
@@ -379,7 +379,7 @@ mod tests {
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
         assert!(!has_more);
 
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
         let counts = count_node_types(trunk);
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 2);
@@ -401,7 +401,7 @@ mod tests {
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
         assert!(!has_more);
 
-        let (trunk, _) = verify_trunk(proof.into_iter().map(|op| Ok(op))).unwrap();
+        let (trunk, _) = verify_trunk(proof.into_iter().map(Ok)).unwrap();
         let counts = count_node_types(trunk);
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 3);
@@ -423,7 +423,7 @@ mod tests {
         let mut iter = merk.db.raw_iterator();
         iter.seek_to_first();
         let chunk = get_next_chunk(&mut iter, None).unwrap();
-        let ops = chunk.into_iter().map(|op| Ok(op));
+        let ops = chunk.into_iter().map(Ok);
         let chunk = verify_leaf(ops, merk.root_hash()).unwrap();
         let counts = count_node_types(chunk);
         assert_eq!(counts.kv, 31);
@@ -436,7 +436,7 @@ mod tests {
 
         // left leaf
         let chunk = get_next_chunk(&mut iter, Some(root_key.as_slice())).unwrap();
-        let ops = chunk.into_iter().map(|op| Ok(op));
+        let ops = chunk.into_iter().map(Ok);
         let chunk = verify_leaf(
             ops,
             [
@@ -452,7 +452,7 @@ mod tests {
 
         // right leaf
         let chunk = get_next_chunk(&mut iter, None).unwrap();
-        let ops = chunk.into_iter().map(|op| Ok(op));
+        let ops = chunk.into_iter().map(Ok);
         let chunk = verify_leaf(
             ops,
             [

--- a/src/proofs/chunk.rs
+++ b/src/proofs/chunk.rs
@@ -331,8 +331,8 @@ mod tests {
     }
 
     #[test]
-    fn one_node_tree_trunk_roundtrip() {
-        let mut tree = BaseTree::new(vec![0], vec![]);
+    fn one_node_tree_trunk_roundtrip() -> Result<()> {
+        let mut tree = BaseTree::new(vec![0], vec![])?;
         tree.commit(&mut NoopCommit {}).unwrap();
 
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
@@ -344,15 +344,16 @@ mod tests {
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 1);
         assert_eq!(counts.kvhash, 0);
+        Ok(())
     }
 
     #[test]
-    fn two_node_right_heavy_tree_trunk_roundtrip() {
+    fn two_node_right_heavy_tree_trunk_roundtrip() -> Result<()> {
         // 0
         //  \
         //   1
         let mut tree =
-            BaseTree::new(vec![0], vec![]).attach(false, Some(BaseTree::new(vec![1], vec![])));
+            BaseTree::new(vec![0], vec![])?.attach(false, Some(BaseTree::new(vec![1], vec![])?));
         tree.commit(&mut NoopCommit {}).unwrap();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
@@ -363,15 +364,16 @@ mod tests {
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 2);
         assert_eq!(counts.kvhash, 0);
+        Ok(())
     }
 
     #[test]
-    fn two_node_left_heavy_tree_trunk_roundtrip() {
+    fn two_node_left_heavy_tree_trunk_roundtrip() -> Result<()> {
         //   1
         //  /
         // 0
         let mut tree =
-            BaseTree::new(vec![1], vec![]).attach(true, Some(BaseTree::new(vec![0], vec![])));
+            BaseTree::new(vec![1], vec![])?.attach(true, Some(BaseTree::new(vec![0], vec![])?));
         tree.commit(&mut NoopCommit {}).unwrap();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
         let (proof, has_more) = walker.create_trunk_proof().unwrap();
@@ -382,16 +384,17 @@ mod tests {
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 2);
         assert_eq!(counts.kvhash, 0);
+        Ok(())
     }
 
     #[test]
-    fn three_node_tree_trunk_roundtrip() {
+    fn three_node_tree_trunk_roundtrip() -> Result<()> {
         //   1
         //  / \
         // 0   2
-        let mut tree = BaseTree::new(vec![1], vec![])
-            .attach(true, Some(BaseTree::new(vec![0], vec![])))
-            .attach(false, Some(BaseTree::new(vec![2], vec![])));
+        let mut tree = BaseTree::new(vec![1], vec![])?
+            .attach(true, Some(BaseTree::new(vec![0], vec![])?))
+            .attach(false, Some(BaseTree::new(vec![2], vec![])?));
         tree.commit(&mut NoopCommit {}).unwrap();
 
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
@@ -403,6 +406,7 @@ mod tests {
         assert_eq!(counts.hash, 0);
         assert_eq!(counts.kv, 3);
         assert_eq!(counts.kvhash, 0);
+        Ok(())
     }
 
     #[test]

--- a/src/proofs/chunk.rs
+++ b/src/proofs/chunk.rs
@@ -125,7 +125,7 @@ where
 pub(crate) fn get_next_chunk(iter: &mut DBRawIterator, end_key: Option<&[u8]>) -> Result<Vec<Op>> {
     let mut chunk = Vec::with_capacity(512);
     let mut stack = Vec::with_capacity(32);
-    let mut node = Tree::new(vec![], vec![]);
+    let mut node = Tree::new(vec![], vec![])?;
 
     while iter.valid() {
         let key = iter.key().unwrap();
@@ -181,8 +181,8 @@ pub(crate) fn verify_leaf<I: Iterator<Item = Result<Op>>>(
         _ => Err(Error::Tree("Leaf chunks must contain full subtree".into())),
     })?;
 
-    if tree.hash() != expected_hash {
-        return Err(Error::HashMismatch(expected_hash, tree.hash()));
+    if tree.hash()? != expected_hash {
+        return Err(Error::HashMismatch(expected_hash, tree.hash()?));
     }
 
     Ok(tree)

--- a/src/proofs/query/mod.rs
+++ b/src/proofs/query/mod.rs
@@ -343,8 +343,8 @@ pub fn verify(bytes: &[u8], expected_hash: Hash) -> Result<Map> {
 
     let root = execute(ops, true, |node| map_builder.insert(node))?;
 
-    if root.hash() != expected_hash {
-        return Err(Error::HashMismatch(expected_hash, root.hash()));
+    if root.hash()? != expected_hash {
+        return Err(Error::HashMismatch(expected_hash, root.hash()?));
     }
 
     Ok(map_builder.build())
@@ -459,8 +459,8 @@ pub fn verify_query(
         }
     }
 
-    if root.hash() != expected_hash {
-        return Err(Error::HashMismatch(expected_hash, root.hash()));
+    if root.hash()? != expected_hash {
+        return Err(Error::HashMismatch(expected_hash, root.hash()?));
     }
 
     Ok(output)

--- a/src/proofs/query/mod.rs
+++ b/src/proofs/query/mod.rs
@@ -475,16 +475,16 @@ mod test {
     use crate::test_utils::make_tree_seq;
     use crate::tree::{NoopCommit, PanicSource, RefWalker, Tree};
 
-    fn make_3_node_tree() -> Tree {
-        let mut tree = Tree::new(vec![5], vec![5])
-            .attach(true, Some(Tree::new(vec![3], vec![3])))
-            .attach(false, Some(Tree::new(vec![7], vec![7])));
+    fn make_3_node_tree() -> Result<Tree> {
+        let mut tree = Tree::new(vec![5], vec![5])?
+            .attach(true, Some(Tree::new(vec![3], vec![3])?))
+            .attach(false, Some(Tree::new(vec![7], vec![7])?));
         tree.commit(&mut NoopCommit {}).expect("commit failed");
-        tree
+        Ok(tree)
     }
 
-    fn verify_keys_test(keys: Vec<Vec<u8>>, expected_result: Vec<Option<Vec<u8>>>) {
-        let mut tree = make_3_node_tree();
+    fn verify_keys_test(keys: Vec<Vec<u8>>, expected_result: Vec<Option<Vec<u8>>>) -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let (proof, _) = walker
@@ -519,59 +519,60 @@ mod test {
         for (key, expected_value) in keys.iter().zip(expected_result.iter()) {
             assert_eq!(values.get(key), expected_value.as_ref());
         }
+        Ok(())
     }
 
     #[test]
-    fn root_verify() {
-        verify_keys_test(vec![vec![5]], vec![Some(vec![5])]);
+    fn root_verify() -> Result<()> {
+        verify_keys_test(vec![vec![5]], vec![Some(vec![5])])
     }
 
     #[test]
-    fn single_verify() {
-        verify_keys_test(vec![vec![3]], vec![Some(vec![3])]);
+    fn single_verify() -> Result<()> {
+        verify_keys_test(vec![vec![3]], vec![Some(vec![3])])
     }
 
     #[test]
-    fn double_verify() {
-        verify_keys_test(vec![vec![3], vec![5]], vec![Some(vec![3]), Some(vec![5])]);
+    fn double_verify() -> Result<()> {
+        verify_keys_test(vec![vec![3], vec![5]], vec![Some(vec![3]), Some(vec![5])])
     }
 
     #[test]
-    fn double_verify_2() {
-        verify_keys_test(vec![vec![3], vec![7]], vec![Some(vec![3]), Some(vec![7])]);
+    fn double_verify_2() -> Result<()> {
+        verify_keys_test(vec![vec![3], vec![7]], vec![Some(vec![3]), Some(vec![7])])
     }
 
     #[test]
-    fn triple_verify() {
+    fn triple_verify() -> Result<()> {
         verify_keys_test(
             vec![vec![3], vec![5], vec![7]],
             vec![Some(vec![3]), Some(vec![5]), Some(vec![7])],
-        );
+        )
     }
 
     #[test]
-    fn left_edge_absence_verify() {
-        verify_keys_test(vec![vec![2]], vec![None]);
+    fn left_edge_absence_verify() -> Result<()> {
+        verify_keys_test(vec![vec![2]], vec![None])
     }
 
     #[test]
-    fn right_edge_absence_verify() {
-        verify_keys_test(vec![vec![8]], vec![None]);
+    fn right_edge_absence_verify() -> Result<()> {
+        verify_keys_test(vec![vec![8]], vec![None])
     }
 
     #[test]
-    fn inner_absence_verify() {
-        verify_keys_test(vec![vec![6]], vec![None]);
+    fn inner_absence_verify() -> Result<()> {
+        verify_keys_test(vec![vec![6]], vec![None])
     }
 
     #[test]
-    fn absent_and_present_verify() {
-        verify_keys_test(vec![vec![5], vec![6]], vec![Some(vec![5]), None]);
+    fn absent_and_present_verify() -> Result<()> {
+        verify_keys_test(vec![vec![5], vec![6]], vec![Some(vec![5]), None])
     }
 
     #[test]
-    fn empty_proof() {
-        let mut tree = make_3_node_tree();
+    fn empty_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let (proof, absence) = walker
@@ -609,11 +610,12 @@ mod test {
         encode_into(proof.iter(), &mut bytes);
         let res = verify_query(bytes.as_slice(), &Query::new(), tree.hash()).unwrap();
         assert!(res.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn root_proof() {
-        let mut tree = make_3_node_tree();
+    fn root_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![5])];
@@ -650,11 +652,12 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![(vec![5], vec![5])]);
+        Ok(())
     }
 
     #[test]
-    fn leaf_proof() {
-        let mut tree = make_3_node_tree();
+    fn leaf_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![3])];
@@ -691,11 +694,12 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![(vec![3], vec![3])]);
+        Ok(())
     }
 
     #[test]
-    fn double_leaf_proof() {
-        let mut tree = make_3_node_tree();
+    fn double_leaf_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![3]), QueryItem::Key(vec![7])];
@@ -726,11 +730,12 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![(vec![3], vec![3]), (vec![7], vec![7]),]);
+        Ok(())
     }
 
     #[test]
-    fn all_nodes_proof() {
-        let mut tree = make_3_node_tree();
+    fn all_nodes_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![
@@ -762,11 +767,12 @@ mod test {
             res,
             vec![(vec![3], vec![3]), (vec![5], vec![5]), (vec![7], vec![7]),]
         );
+        Ok(())
     }
 
     #[test]
-    fn global_edge_absence_proof() {
-        let mut tree = make_3_node_tree();
+    fn global_edge_absence_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![8])];
@@ -803,11 +809,12 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![]);
+        Ok(())
     }
 
     #[test]
-    fn absence_proof() {
-        let mut tree = make_3_node_tree();
+    fn absence_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![6])];
@@ -838,21 +845,22 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![]);
+        Ok(())
     }
 
     #[test]
-    fn doc_proof() {
-        let mut tree = Tree::new(vec![5], vec![5])
+    fn doc_proof() -> Result<()> {
+        let mut tree = Tree::new(vec![5], vec![5])?
             .attach(
                 true,
                 Some(
-                    Tree::new(vec![2], vec![2])
-                        .attach(true, Some(Tree::new(vec![1], vec![1])))
+                    Tree::new(vec![2], vec![2])?
+                        .attach(true, Some(Tree::new(vec![1], vec![1])?))
                         .attach(
                             false,
                             Some(
-                                Tree::new(vec![4], vec![4])
-                                    .attach(true, Some(Tree::new(vec![3], vec![3]))),
+                                Tree::new(vec![4], vec![4])?
+                                    .attach(true, Some(Tree::new(vec![3], vec![3])?)),
                             ),
                         ),
                 ),
@@ -860,20 +868,20 @@ mod test {
             .attach(
                 false,
                 Some(
-                    Tree::new(vec![9], vec![9])
+                    Tree::new(vec![9], vec![9])?
                         .attach(
                             true,
                             Some(
-                                Tree::new(vec![7], vec![7])
-                                    .attach(true, Some(Tree::new(vec![6], vec![6])))
-                                    .attach(false, Some(Tree::new(vec![8], vec![8]))),
+                                Tree::new(vec![7], vec![7])?
+                                    .attach(true, Some(Tree::new(vec![6], vec![6])?))
+                                    .attach(false, Some(Tree::new(vec![8], vec![8])?)),
                             ),
                         )
                         .attach(
                             false,
                             Some(
-                                Tree::new(vec![11], vec![11])
-                                    .attach(true, Some(Tree::new(vec![10], vec![10]))),
+                                Tree::new(vec![11], vec![11])?
+                                    .attach(true, Some(Tree::new(vec![10], vec![10])?)),
                             ),
                         ),
                 ),
@@ -948,6 +956,7 @@ mod test {
                 (vec![4], vec![4]),
             ]
         );
+        Ok(())
     }
 
     #[test]
@@ -1403,8 +1412,8 @@ mod test {
     }
 
     #[test]
-    fn verify_ops() {
-        let mut tree = Tree::new(vec![5], vec![5]);
+    fn verify_ops() -> Result<()> {
+        let mut tree = Tree::new(vec![5], vec![5])?;
         tree.commit(&mut NoopCommit {}).expect("commit failed");
 
         let root_hash = tree.hash();
@@ -1422,12 +1431,13 @@ mod test {
             map.get(vec![5].as_slice()).unwrap().unwrap(),
             vec![5].as_slice()
         );
+        Ok(())
     }
 
     #[test]
     #[should_panic(expected = "verify failed")]
     fn verify_ops_mismatched_hash() {
-        let mut tree = Tree::new(vec![5], vec![5]);
+        let mut tree = Tree::new(vec![5], vec![5]).expect("tree construction failed");
         tree.commit(&mut NoopCommit {}).expect("commit failed");
 
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
@@ -1445,7 +1455,7 @@ mod test {
     #[test]
     #[should_panic(expected = "verify failed")]
     fn verify_query_mismatched_hash() {
-        let mut tree = make_3_node_tree();
+        let mut tree = make_3_node_tree().expect("tree construction failed");
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
         let keys = vec![vec![5], vec![7]];
         let (proof, _) = walker

--- a/src/proofs/tree.rs
+++ b/src/proofs/tree.rs
@@ -1,6 +1,6 @@
 use super::{Node, Op};
 use crate::error::{Error, Result};
-use crate::tree::{kv_hash, node_hash, Hash, NULL_HASH};
+use crate::tree::{kv_hash, node_hash, Hash, Hasher, NULL_HASH};
 
 /// Contains a tree's child node and its hash. The hash can always be assumed to
 /// be up-to-date.
@@ -51,7 +51,7 @@ impl Tree {
         match &self.node {
             Node::Hash(hash) => Ok(*hash),
             Node::KVHash(kv_hash) => Ok(compute_hash(self, *kv_hash)),
-            Node::KV(key, value) => kv_hash(key.as_slice(), value.as_slice())
+            Node::KV(key, value) => kv_hash::<Hasher>(key.as_slice(), value.as_slice())
                 .map(|kv_hash| compute_hash(self, kv_hash))
                 .map_err(Into::into),
         }

--- a/src/proofs/tree.rs
+++ b/src/proofs/tree.rs
@@ -329,10 +329,12 @@ mod test {
             assert_eq!(tree.height, expected_height);
             tree.left
                 .as_ref()
-                .map(|l| recurse(&l.tree, expected_height - 1));
+                .into_iter()
+                .for_each(|l| recurse(&l.tree, expected_height - 1));
             tree.right
                 .as_ref()
-                .map(|r| recurse(&r.tree, expected_height - 1));
+                .into_iter()
+                .for_each(|r| recurse(&r.tree, expected_height - 1));
         }
 
         let tree = make_7_node_prooftree();

--- a/src/proofs/tree.rs
+++ b/src/proofs/tree.rs
@@ -35,7 +35,9 @@ impl From<Node> for Tree {
 impl PartialEq for Tree {
     /// Checks equality for the root hashes of the two trees.
     fn eq(&self, other: &Self) -> bool {
-        self.hash().and_then(|this_hash| other.hash().map(|other_hash| this_hash == other_hash)).unwrap_or_default()
+        self.hash()
+            .and_then(|this_hash| other.hash().map(|other_hash| this_hash == other_hash))
+            .unwrap_or_default()
     }
 }
 
@@ -49,7 +51,9 @@ impl Tree {
         match &self.node {
             Node::Hash(hash) => Ok(*hash),
             Node::KVHash(kv_hash) => Ok(compute_hash(self, *kv_hash)),
-            Node::KV(key, value) => kv_hash(key.as_slice(), value.as_slice()).map(|kv_hash| compute_hash(self, kv_hash)).map_err(Into::into)
+            Node::KV(key, value) => kv_hash(key.as_slice(), value.as_slice())
+                .map(|kv_hash| compute_hash(self, kv_hash))
+                .map_err(Into::into),
         }
     }
 
@@ -246,12 +250,26 @@ where
         match op? {
             Op::Parent => {
                 let (mut parent, child) = (try_pop(&mut stack)?, try_pop(&mut stack)?);
-                parent.attach(true, if collapse { child.try_into_hash()? } else { child })?;
+                parent.attach(
+                    true,
+                    if collapse {
+                        child.try_into_hash()?
+                    } else {
+                        child
+                    },
+                )?;
                 stack.push(parent);
             }
             Op::Child => {
                 let (child, mut parent) = (try_pop(&mut stack)?, try_pop(&mut stack)?);
-                parent.attach(false, if collapse { child.try_into_hash()? } else { child })?;
+                parent.attach(
+                    false,
+                    if collapse {
+                        child.try_into_hash()?
+                    } else {
+                        child
+                    },
+                )?;
                 stack.push(parent);
             }
             Op::Push(node) => {

--- a/src/proofs/tree.rs
+++ b/src/proofs/tree.rs
@@ -35,24 +35,21 @@ impl From<Node> for Tree {
 impl PartialEq for Tree {
     /// Checks equality for the root hashes of the two trees.
     fn eq(&self, other: &Self) -> bool {
-        self.hash() == other.hash()
+        self.hash().and_then(|this_hash| other.hash().map(|other_hash| this_hash == other_hash)).unwrap_or_default()
     }
 }
 
 impl Tree {
     /// Gets or computes the hash for this tree node.
-    pub fn hash(&self) -> Hash {
+    pub fn hash(&self) -> Result<Hash> {
         fn compute_hash(tree: &Tree, kv_hash: Hash) -> Hash {
             node_hash(&kv_hash, &tree.child_hash(true), &tree.child_hash(false))
         }
 
         match &self.node {
-            Node::Hash(hash) => *hash,
-            Node::KVHash(kv_hash) => compute_hash(self, *kv_hash),
-            Node::KV(key, value) => {
-                let kv_hash = kv_hash(key.as_slice(), value.as_slice());
-                compute_hash(self, kv_hash)
-            }
+            Node::Hash(hash) => Ok(*hash),
+            Node::KVHash(kv_hash) => Ok(compute_hash(self, *kv_hash)),
+            Node::KV(key, value) => kv_hash(key.as_slice(), value.as_slice()).map(|kv_hash| compute_hash(self, kv_hash)).map_err(Into::into)
         }
     }
 
@@ -120,7 +117,7 @@ impl Tree {
 
         self.height = self.height.max(child.height + 1);
 
-        let hash = child.hash();
+        let hash = child.hash()?;
         let tree = Box::new(child);
         *self.child_mut(left) = Some(Child { tree, hash });
 
@@ -137,8 +134,8 @@ impl Tree {
 
     /// Consumes the tree node, calculates its hash, and returns a `Node::Hash`
     /// variant.
-    fn into_hash(self) -> Tree {
-        Node::Hash(self.hash()).into()
+    fn try_into_hash(self) -> Result<Tree> {
+        self.hash().map(Node::Hash).map(Into::into)
     }
 
     #[cfg(feature = "full")]
@@ -249,12 +246,12 @@ where
         match op? {
             Op::Parent => {
                 let (mut parent, child) = (try_pop(&mut stack)?, try_pop(&mut stack)?);
-                parent.attach(true, if collapse { child.into_hash() } else { child })?;
+                parent.attach(true, if collapse { child.try_into_hash()? } else { child })?;
                 stack.push(parent);
             }
             Op::Child => {
                 let (child, mut parent) = (try_pop(&mut stack)?, try_pop(&mut stack)?);
-                parent.attach(false, if collapse { child.into_hash() } else { child })?;
+                parent.attach(false, if collapse { child.try_into_hash()? } else { child })?;
                 stack.push(parent);
             }
             Op::Push(node) => {

--- a/src/proofs/tree.rs
+++ b/src/proofs/tree.rs
@@ -45,7 +45,7 @@ impl Tree {
     /// Gets or computes the hash for this tree node.
     pub fn hash(&self) -> Result<Hash> {
         fn compute_hash(tree: &Tree, kv_hash: Hash) -> Hash {
-            node_hash(&kv_hash, &tree.child_hash(true), &tree.child_hash(false))
+            node_hash::<Hasher>(&kv_hash, &tree.child_hash(true), &tree.child_hash(false))
         }
 
         match &self.node {

--- a/src/test_utils/crash_merk.rs
+++ b/src/test_utils/crash_merk.rs
@@ -74,7 +74,7 @@ mod tests {
     fn crash() {
         let path = std::thread::current().name().unwrap().to_owned();
 
-        let mut merk = CrashMerk::open(&path).expect("failed to open merk");
+        let mut merk = CrashMerk::open(path).expect("failed to open merk");
         merk.apply(&[(vec![1, 2, 3], Op::Put(vec![4, 5, 6]))], &[])
             .expect("apply failed");
         unsafe {

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -124,7 +124,7 @@ pub fn make_tree_rand(node_count: u64, batch_size: u64, initial_seed: u64) -> Tr
     assert!((node_count % batch_size) == 0);
 
     let value = vec![123; 60];
-    let mut tree = Tree::new(vec![0; 20], value);
+    let mut tree = Tree::new(vec![0; 20], value).expect("Tree construction failed");
 
     let mut seed = initial_seed;
 
@@ -147,7 +147,7 @@ pub fn make_tree_seq(node_count: u64) -> Tree {
     };
 
     let value = vec![123; 60];
-    let mut tree = Tree::new(vec![0; 20], value);
+    let mut tree = Tree::new(vec![0; 20], value).expect("Tree construction failed");
 
     let batch_count = node_count / batch_size;
     for i in 0..batch_count {

--- a/src/test_utils/temp_merk.rs
+++ b/src/test_utils/temp_merk.rs
@@ -28,7 +28,7 @@ impl TempMerk {
             .unwrap()
             .as_nanos();
         let mut path = temp_dir();
-        path.push(format!("merk-temp–{}", time));
+        path.push(format!("merk-temp–{time}"));
         path
     }
 }

--- a/src/tree/encoding.rs
+++ b/src/tree/encoding.rs
@@ -40,6 +40,7 @@ impl Tree {
 mod tests {
     use super::super::Link;
     use super::*;
+    use crate::error::Result;
 
     #[test]
     fn encode_leaf_tree() {
@@ -64,7 +65,7 @@ mod tests {
             Some(Link::Modified {
                 pending_writes: 1,
                 child_heights: (123, 124),
-                tree: Tree::new(vec![2], vec![3]),
+                tree: Tree::new(vec![2], vec![3]).unwrap(),
             }),
             None,
         );
@@ -72,7 +73,7 @@ mod tests {
     }
 
     #[test]
-    fn encode_loaded_tree() {
+    fn encode_loaded_tree() -> Result<()> {
         let tree = Tree::from_fields(
             vec![0],
             vec![1],
@@ -80,7 +81,7 @@ mod tests {
             Some(Link::Loaded {
                 hash: [66; 32],
                 child_heights: (123, 124),
-                tree: Tree::new(vec![2], vec![3]),
+                tree: Tree::new(vec![2], vec![3])?,
             }),
             None,
         );
@@ -93,10 +94,11 @@ mod tests {
                 55, 55, 55, 55, 55, 55, 55, 55, 1
             ]
         );
+        Ok(())
     }
 
     #[test]
-    fn encode_uncommitted_tree() {
+    fn encode_uncommitted_tree() -> Result<()> {
         let tree = Tree::from_fields(
             vec![0],
             vec![1],
@@ -104,7 +106,7 @@ mod tests {
             Some(Link::Uncommitted {
                 hash: [66; 32],
                 child_heights: (123, 124),
-                tree: Tree::new(vec![2], vec![3]),
+                tree: Tree::new(vec![2], vec![3])?,
             }),
             None,
         );
@@ -117,6 +119,7 @@ mod tests {
                 55, 55, 55, 55, 55, 55, 55, 55, 1
             ]
         );
+        Ok(())
     }
 
     #[test]

--- a/src/tree/encoding.rs
+++ b/src/tree/encoding.rs
@@ -176,8 +176,8 @@ mod tests {
         }) = tree.link(true)
         {
             assert_eq!(*key, [2]);
-            assert_eq!(*child_heights, (123 as u8, 124 as u8));
-            assert_eq!(*hash, [66 as u8; 32]);
+            assert_eq!(*child_heights, (123_u8, 124_u8));
+            assert_eq!(*hash, [66_u8; 32]);
         } else {
             panic!("Expected Link::Reference");
         }

--- a/src/tree/hash.rs
+++ b/src/tree/hash.rs
@@ -23,19 +23,20 @@ pub fn kv_hash(key: &[u8], value: &[u8]) -> Result<Hash, TryFromIntError> {
     let mut hasher = Hasher::new();
     hasher.update(&[0]);
 
-    u32::try_from(key.len()).and_then(|key| u32::try_from(value.len()).map(|value| (key, value)))
-    .map(|(key_length, val_length)| {
-        hasher.update(&key_length.to_le_bytes());
-        hasher.update(key);
+    u32::try_from(key.len())
+        .and_then(|key| u32::try_from(value.len()).map(|value| (key, value)))
+        .map(|(key_length, val_length)| {
+            hasher.update(&key_length.to_le_bytes());
+            hasher.update(key);
 
-        hasher.update(&val_length.to_le_bytes());
-        hasher.update(value);
+            hasher.update(&val_length.to_le_bytes());
+            hasher.update(value);
 
-        let res = hasher.finalize();
-        let mut hash: Hash = Default::default();
-        hash.copy_from_slice(&res[..]);
-        hash
-    })
+            let res = hasher.finalize();
+            let mut hash: Hash = Default::default();
+            hash.copy_from_slice(&res[..]);
+            hash
+        })
 }
 
 /// Hashes a node based on the hash of its key/value pair, the hash of its left

--- a/src/tree/hash.rs
+++ b/src/tree/hash.rs
@@ -39,9 +39,8 @@ pub fn kv_hash<D: Digest>(key: &[u8], value: &[u8]) -> Result<Hash, TryFromIntEr
 
 /// Hashes a node based on the hash of its key/value pair, the hash of its left
 /// child (if any), and the hash of its right child (if any).
-pub fn node_hash(kv: &Hash, left: &Hash, right: &Hash) -> Hash {
-    // TODO: make generic to allow other hashers
-    let mut hasher = Hasher::new();
+pub fn node_hash<D: Digest>(kv: &Hash, left: &Hash, right: &Hash) -> Hash {
+    let mut hasher = D::new();
     hasher.update([1]);
     hasher.update(kv);
     hasher.update(left);

--- a/src/tree/hash.rs
+++ b/src/tree/hash.rs
@@ -18,7 +18,6 @@ pub type Hash = [u8; HASH_LENGTH];
 /// **NOTE:** This will fail if the key is longer than 255 bytes, or the value
 /// is longer than 65,535 bytes.
 pub fn kv_hash<D: Digest>(key: &[u8], value: &[u8]) -> Result<Hash, TryFromIntError> {
-    // TODO: make generic to allow other hashers
     let mut hasher = D::new();
     hasher.update(&[0]);
 

--- a/src/tree/hash.rs
+++ b/src/tree/hash.rs
@@ -19,15 +19,15 @@ pub type Hash = [u8; HASH_LENGTH];
 /// is longer than 65,535 bytes.
 pub fn kv_hash<D: Digest>(key: &[u8], value: &[u8]) -> Result<Hash, TryFromIntError> {
     let mut hasher = D::new();
-    hasher.update(&[0]);
+    hasher.update([0]);
 
     u32::try_from(key.len())
         .and_then(|key| u32::try_from(value.len()).map(|value| (key, value)))
         .map(|(key_length, val_length)| {
-            hasher.update(&key_length.to_le_bytes());
+            hasher.update(key_length.to_le_bytes());
             hasher.update(key);
 
-            hasher.update(&val_length.to_le_bytes());
+            hasher.update(val_length.to_le_bytes());
             hasher.update(value);
 
             let res = hasher.finalize();
@@ -42,7 +42,7 @@ pub fn kv_hash<D: Digest>(key: &[u8], value: &[u8]) -> Result<Hash, TryFromIntEr
 pub fn node_hash(kv: &Hash, left: &Hash, right: &Hash) -> Hash {
     // TODO: make generic to allow other hashers
     let mut hasher = Hasher::new();
-    hasher.update(&[1]);
+    hasher.update([1]);
     hasher.update(kv);
     hasher.update(left);
     hasher.update(right);

--- a/src/tree/hash.rs
+++ b/src/tree/hash.rs
@@ -15,12 +15,11 @@ pub type Hash = [u8; HASH_LENGTH];
 
 /// Hashes a key/value pair.
 ///
-/// **NOTE:** This will panic if the key is longer than 255 bytes, or the value
+/// **NOTE:** This will fail if the key is longer than 255 bytes, or the value
 /// is longer than 65,535 bytes.
-pub fn kv_hash(key: &[u8], value: &[u8]) -> Result<Hash, TryFromIntError> {
-    // TODO: result instead of panic
+pub fn kv_hash<D: Digest>(key: &[u8], value: &[u8]) -> Result<Hash, TryFromIntError> {
     // TODO: make generic to allow other hashers
-    let mut hasher = Hasher::new();
+    let mut hasher = D::new();
     hasher.update(&[0]);
 
     u32::try_from(key.len())

--- a/src/tree/kv.rs
+++ b/src/tree/kv.rs
@@ -1,6 +1,9 @@
 use super::hash::{kv_hash, Hash, HASH_LENGTH, NULL_HASH};
 use ed::{Decode, Encode, Result};
-use std::{io::{Read, Write}, num::TryFromIntError};
+use std::{
+    io::{Read, Write},
+    num::TryFromIntError,
+};
 
 // TODO: maybe use something similar to Vec but without capacity field,
 //       (should save 16 bytes per entry). also, maybe a shorter length
@@ -107,22 +110,22 @@ mod test {
     use super::*;
 
     #[test]
-    fn new_kv() -> Result<(), TryFromIntError> {
-        let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6]);
+    fn new_kv() -> std::result::Result<(), TryFromIntError> {
+        let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6])?;
 
         assert_eq!(kv.key(), &[1, 2, 3]);
         assert_eq!(kv.value(), &[4, 5, 6]);
-        assert_ne!(kv.hash()?, &super::super::hash::NULL_HASH);
+        assert_ne!(kv.hash(), &super::super::hash::NULL_HASH);
         Ok(())
     }
 
     #[test]
-    fn with_value() -> Result<(), TryFromIntError> {
-        let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6]).with_value(vec![7, 8, 9]);
+    fn with_value() -> std::result::Result<(), TryFromIntError> {
+        let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6])?.with_value(vec![7, 8, 9])?;
 
         assert_eq!(kv.key(), &[1, 2, 3]);
         assert_eq!(kv.value(), &[7, 8, 9]);
-        assert_ne!(kv.hash()?, &super::super::hash::NULL_HASH);
+        assert_ne!(kv.hash(), &super::super::hash::NULL_HASH);
         Ok(())
     }
 }

--- a/src/tree/kv.rs
+++ b/src/tree/kv.rs
@@ -1,4 +1,4 @@
-use super::hash::{kv_hash, Hash, HASH_LENGTH, NULL_HASH};
+use super::hash::{kv_hash, Hash, Hasher, HASH_LENGTH, NULL_HASH};
 use ed::{Decode, Encode, Result};
 use std::{
     io::{Read, Write},
@@ -21,7 +21,7 @@ impl KV {
     /// Creates a new `KV` with the given key and value and computes its hash.
     #[inline]
     pub fn new(key: Vec<u8>, value: Vec<u8>) -> std::result::Result<Self, TryFromIntError> {
-        kv_hash(key.as_slice(), value.as_slice()).map(|hash| KV { key, value, hash })
+        kv_hash::<Hasher>(key.as_slice(), value.as_slice()).map(|hash| KV { key, value, hash })
     }
 
     /// Creates a new `KV` with the given key, value, and hash. The hash is not
@@ -36,7 +36,7 @@ impl KV {
     #[inline]
     pub fn with_value(mut self, value: Vec<u8>) -> std::result::Result<Self, TryFromIntError> {
         self.value = value;
-        self.hash = kv_hash(self.key(), self.value())?;
+        self.hash = kv_hash::<Hasher>(self.key(), self.value())?;
         Ok(self)
     }
 

--- a/src/tree/link.rs
+++ b/src/tree/link.rs
@@ -402,18 +402,17 @@ mod test {
     }
 
     #[test]
-    fn modified_hash() -> std::result::Result<(), ()> {
-        match Tree::new(vec![0], vec![1])
+    #[should_panic(expected = "Cannot get hash from modified link")]
+    fn modified_hash() {
+        Tree::new(vec![0], vec![1])
             .map(|tree| Link::Modified {
                 pending_writes: 1,
                 child_heights: (1, 1),
                 tree,
             })
             .map(|link| link.hash().to_vec())
-        {
-            Ok(_) => Err(()),
-            Err(_) => Ok(()),
-        }
+            .map(|_| ())
+            .unwrap_or_default()
     }
 
     #[test]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -155,7 +155,7 @@ impl Tree {
     /// Computes and returns the hash of the root node.
     #[inline]
     pub fn hash(&self) -> Hash {
-        node_hash(
+        node_hash::<Hasher>(
             self.inner.kv.hash(),
             self.child_hash(true),
             self.child_hash(false),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -16,7 +16,7 @@ use ed::{Decode, Encode};
 
 use super::error::Result;
 pub use commit::{Commit, NoopCommit};
-pub use hash::{kv_hash, node_hash, Hash, HASH_LENGTH, NULL_HASH};
+pub use hash::{kv_hash, node_hash, Hash, Hasher, HASH_LENGTH, NULL_HASH};
 use kv::KV;
 pub use link::Link;
 pub use ops::{Batch, BatchEntry, Op, PanicSource};

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -47,14 +47,16 @@ impl Tree {
     /// Creates a new `Tree` with the given key and value, and no children.
     ///
     /// Hashes the key/value pair and initializes the `kv_hash` field.
-    pub fn new(key: Vec<u8>, value: Vec<u8>) -> Self {
-        Tree {
-            inner: Box::new(TreeInner {
-                kv: KV::new(key, value),
-                left: None,
-                right: None,
-            }),
-        }
+    pub fn new(key: Vec<u8>, value: Vec<u8>) -> Result<Self> {
+        KV::new(key, value).map_err(Into::into).map(|kv|
+            Tree {
+                inner: Box::new(TreeInner {
+                    kv,
+                    left: None,
+                    right: None,
+                }),
+            }
+        )
     }
 
     /// Creates a `Tree` by supplying all the raw struct fields (mainly useful
@@ -307,9 +309,9 @@ impl Tree {
     /// Replaces the root node's value with the given value and returns the
     /// modified `Tree`.
     #[inline]
-    pub fn with_value(mut self, value: Vec<u8>) -> Self {
-        self.inner.kv = self.inner.kv.with_value(value);
-        self
+    pub fn with_value(mut self, value: Vec<u8>) -> Result<Self> {
+        self.inner.kv = self.inner.kv.with_value(value)?;
+        Ok(self)
     }
 
     // TODO: add compute_hashes method

--- a/src/tree/ops.rs
+++ b/src/tree/ops.rs
@@ -95,7 +95,7 @@ where
         };
 
         // TODO: take from batch so we don't have to clone
-        let mid_tree = Tree::new(mid_key.to_vec(), mid_value.to_vec());
+        let mid_tree = Tree::new(mid_key.to_vec(), mid_value.to_vec())?;
         let mid_walker = Walker::new(mid_tree, PanicSource {});
         Ok(mid_walker
             .recurse(batch, mid_index, true)?
@@ -143,7 +143,7 @@ where
                 }
             }
         } else {
-            self
+            Ok(self)
         };
 
         let (mid, exclusive) = match search {
@@ -151,7 +151,7 @@ where
             Err(index) => (index, false),
         };
 
-        tree.recurse(batch, mid, exclusive)
+        tree?.recurse(batch, mid, exclusive)
     }
 
     /// Recursively applies operations to the tree's children (if there are any

--- a/src/tree/ops.rs
+++ b/src/tree/ops.rs
@@ -16,7 +16,7 @@ impl fmt::Debug for Op {
             f,
             "{}",
             match self {
-                Put(value) => format!("Put({:?})", value),
+                Put(value) => format!("Put({value:?})"),
                 Delete => "Delete".to_string(),
             }
         )
@@ -456,8 +456,7 @@ mod test {
     #[test]
     fn apply_empty_none() {
         let (maybe_tree, deleted_keys) =
-            Walker::<PanicSource>::apply_to(None, &vec![], PanicSource {})
-                .expect("apply_to failed");
+            Walker::<PanicSource>::apply_to(None, &[], PanicSource {}).expect("apply_to failed");
         assert!(maybe_tree.is_none());
         assert!(deleted_keys.is_empty());
     }

--- a/src/tree/ops.rs
+++ b/src/tree/ops.rs
@@ -1,4 +1,4 @@
-use super::{Fetch, Link, Tree, Walker};
+use super::{Fetch, Tree, Walker};
 use crate::error::Result;
 use std::collections::LinkedList;
 use std::fmt;
@@ -35,7 +35,7 @@ pub type Batch = [BatchEntry];
 pub struct PanicSource {}
 
 impl Fetch for PanicSource {
-    fn fetch_by_key(&self, key: &[u8]) -> Result<Option<Tree>> {
+    fn fetch_by_key(&self, _: &[u8]) -> Result<Option<Tree>> {
         unreachable!()
     }
 }

--- a/src/tree/walk/fetch.rs
+++ b/src/tree/walk/fetch.rs
@@ -15,6 +15,6 @@ pub trait Fetch {
 
     fn fetch_by_key_expect(&self, key: &[u8]) -> Result<Tree> {
         self.fetch_by_key(key)?
-            .ok_or_else(|| Error::Key(format!("Key does not exist: {:?}", key)))
+            .ok_or_else(|| Error::Key(format!("Key does not exist: {key:?}")))
     }
 }

--- a/src/tree/walk/mod.rs
+++ b/src/tree/walk/mod.rs
@@ -128,9 +128,9 @@ where
     }
 
     /// Similar to `Tree#with_value`.
-    pub fn with_value(mut self, value: Vec<u8>) -> Self {
-        self.tree.own(|t| t.with_value(value));
-        self
+    pub fn with_value(mut self, value: Vec<u8>) -> Result<Self> {
+        self.tree.own_fallible(|t| t.with_value(value))?;
+        Ok(self)
     }
 }
 

--- a/src/tree/walk/mod.rs
+++ b/src/tree/walk/mod.rs
@@ -154,14 +154,14 @@ mod test {
 
     impl Fetch for MockSource {
         fn fetch_by_key(&self, key: &[u8]) -> Result<Option<Tree>> {
-            Ok(Some(Tree::new(key.to_vec(), b"foo".to_vec())))
+            Tree::new(key.to_vec(), b"foo".to_vec()).map(Some)
         }
     }
 
     #[test]
-    fn walk_modified() {
-        let tree = Tree::new(b"test".to_vec(), b"abc".to_vec())
-            .attach(true, Some(Tree::new(b"foo".to_vec(), b"bar".to_vec())));
+    fn walk_modified() -> Result<()> {
+        let tree = Tree::new(b"test".to_vec(), b"abc".to_vec())?
+            .attach(true, Some(Tree::new(b"foo".to_vec(), b"bar".to_vec())?));
 
         let source = MockSource {};
         let walker = Walker::new(tree, source);
@@ -173,12 +173,13 @@ mod test {
             })
             .expect("walk failed");
         assert!(walker.into_inner().child(true).is_none());
+        Ok(())
     }
 
     #[test]
-    fn walk_stored() {
-        let mut tree = Tree::new(b"test".to_vec(), b"abc".to_vec())
-            .attach(true, Some(Tree::new(b"foo".to_vec(), b"bar".to_vec())));
+    fn walk_stored() -> Result<()> {
+        let mut tree = Tree::new(b"test".to_vec(), b"abc".to_vec())?
+            .attach(true, Some(Tree::new(b"foo".to_vec(), b"bar".to_vec())?));
         tree.commit(&mut NoopCommit {}).expect("commit failed");
 
         let source = MockSource {};
@@ -191,6 +192,7 @@ mod test {
             })
             .expect("walk failed");
         assert!(walker.into_inner().child(true).is_none());
+        Ok(())
     }
 
     #[test]
@@ -220,8 +222,8 @@ mod test {
     }
 
     #[test]
-    fn walk_none() {
-        let tree = Tree::new(b"test".to_vec(), b"abc".to_vec());
+    fn walk_none() -> Result<()> {
+        let tree = Tree::new(b"test".to_vec(), b"abc".to_vec())?;
 
         let source = MockSource {};
         let walker = Walker::new(tree, source);
@@ -232,5 +234,6 @@ mod test {
                 Ok(None)
             })
             .expect("walk failed");
+        Ok(())
     }
 }


### PR DESCRIPTION
As the title states, this PR addresses two TODOs related to the kv_hash function.  In the first, it changes the behaviour from panicking on a failed range check to returning an error.  It also allows for different hashes to be used with the same function.  This is achieved by changing the function signature from

```
fn kv_hash(key: &[u8], value: &[u8]) -> Hash
```
to
```
fn kv_hash<D: Digest>(key: &[u8], value: &[u8]) -> Result<Hash, TryFromIntError>
```

The return type is also reflected in the node_hash function, which changes from 

```
pub fn node_hash(kv: &Hash, left: &Hash, right: &Hash) -> Hash
```
to
```
pub fn node_hash<D: Digest>(kv: &Hash, left: &Hash, right: &Hash) -> Hash
```