### PR TITLE
Return errors involving missing links instead of panicking

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,12 @@ pub enum Error {
     KeyNotFound(String),
     #[error("Proof is missing data for query")]
     MissingData,
+    #[error("Expected link")]
+    MissingLink,
+    #[error("Expected Some(Link::Reference)")]
+    MissingLinkReference,
+    #[error("Cannot traverse Link::Modified")]
+    ModifiedLinkTraversal,
     #[error("Path Error: {0}")]
     Path(String),
     #[error("Proof Error: {0}")]

--- a/src/tree/walk/ref_walker.rs
+++ b/src/tree/walk/ref_walker.rs
@@ -1,6 +1,6 @@
 use super::super::{Link, Tree};
 use super::Fetch;
-use crate::error::Result;
+use crate::error::{Error::ModifiedLinkTraversal, Result};
 
 /// Allows read-only traversal of a `Tree`, fetching from the given source when
 /// traversing to a pruned node. The fetched nodes are then retained in memory
@@ -22,7 +22,6 @@ where
 {
     /// Creates a `RefWalker` with the given tree and source.
     pub fn new(tree: &'a mut Tree, source: S) -> Self {
-        // TODO: check if tree has modified links, panic if so
         RefWalker { tree, source }
     }
 
@@ -41,12 +40,10 @@ where
         };
 
         match link {
-            Link::Reference { .. } => {
-                self.tree.load(left, &self.source)?;
-            }
-            Link::Modified { .. } => panic!("Cannot traverse Link::Modified"),
-            Link::Uncommitted { .. } | Link::Loaded { .. } => {}
-        }
+            Link::Reference { .. } => self.tree.load(left, &self.source),
+            Link::Modified { .. } => Err(ModifiedLinkTraversal),
+            Link::Uncommitted { .. } | Link::Loaded { .. } => Ok(()),
+        }?;
 
         let child = self.tree.child_mut(left).unwrap();
         Ok(Some(RefWalker::new(child, self.source.clone())))


### PR DESCRIPTION
This PR clears a TODO involving removing panics in the code where there is an attempt to traverse over a link or where there is missing link or related link data.