### PR TITLE
V1 migration

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
     UnexpectedNode(String),
     #[error("Unknown Error")]
     Unknown,
+    #[error("Version Error: {0}")]
+    Version(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/merk/mod.rs
+++ b/src/merk/mod.rs
@@ -17,8 +17,11 @@ use crate::tree::{Batch, Commit, Fetch, GetResult, Hash, Op, RefWalker, Tree, Wa
 pub use self::snapshot::Snapshot;
 
 const ROOT_KEY_KEY: &[u8] = b"root";
+const FORMAT_VERSION_KEY: &[u8] = b"format";
 const AUX_CF_NAME: &str = "aux";
 const INTERNAL_CF_NAME: &str = "internal";
+
+const FORMAT_VERSION: u64 = 1;
 
 fn column_families() -> Vec<ColumnFamilyDescriptor> {
     vec![
@@ -390,6 +393,14 @@ impl Merk {
                 Op::Delete => batch.delete_cf(aux_cf, key),
             };
         }
+
+        // update format version
+        // TODO: shouldn't need a write per commit
+        batch.put_cf(
+            internal_cf,
+            FORMAT_VERSION_KEY,
+            &FORMAT_VERSION.to_be_bytes(),
+        );
 
         // write to db
         self.write(batch)?;

--- a/src/merk/mod.rs
+++ b/src/merk/mod.rs
@@ -425,7 +425,7 @@ impl Merk {
         batch.put_cf(
             internal_cf,
             FORMAT_VERSION_KEY,
-            &FORMAT_VERSION.to_be_bytes(),
+            FORMAT_VERSION.to_be_bytes(),
         );
 
         // write to db

--- a/src/merk/mod.rs
+++ b/src/merk/mod.rs
@@ -81,6 +81,16 @@ impl Merk {
         })
     }
 
+    pub fn open_and_get_aux<P>(path: P, key: &[u8]) -> Result<Option<Vec<u8>>>
+    where
+        P: AsRef<Path>,
+    {
+        let db_opts = Merk::default_db_opts();
+        let db = rocksdb::DB::open_cf_descriptors(&db_opts, path, column_families())?;
+        let aux_cf = db.cf_handle(AUX_CF_NAME).unwrap();
+        Ok(db.get_cf(aux_cf, key)?)
+    }
+
     pub fn default_db_opts() -> rocksdb::Options {
         let mut opts = rocksdb::Options::default();
         opts.create_if_missing(true);

--- a/src/tree/encoding.rs
+++ b/src/tree/encoding.rs
@@ -1,4 +1,8 @@
-use super::Tree;
+use std::io::Read;
+
+use crate::Result;
+
+use super::{kv::KV, Link, Tree, TreeInner};
 use ed::{Decode, Encode};
 
 impl Tree {
@@ -33,6 +37,30 @@ impl Tree {
         let mut tree: Tree = Decode::decode(input).unwrap();
         tree.inner.kv.key = key;
         tree
+    }
+
+    pub fn decode_v0<R: Read>(mut input: R) -> Result<Self> {
+        let mut read_link_v0 = || -> Result<Option<Link>> {
+            let some = bool::decode(&mut input)?;
+            if some {
+                let link = Link::decode_v0(&mut input)?;
+                Ok(Some(link))
+            } else {
+                Ok(None)
+            }
+        };
+
+        let maybe_left = read_link_v0()?;
+        let maybe_right = read_link_v0()?;
+        let kv = KV::decode(&mut input)?;
+
+        Ok(Tree {
+            inner: Box::new(TreeInner {
+                left: maybe_left,
+                right: maybe_right,
+                kv,
+            }),
+        })
     }
 }
 

--- a/src/tree/link.rs
+++ b/src/tree/link.rs
@@ -24,11 +24,10 @@ pub enum Link {
     /// Represents a tree node which has been modified since the `Tree`'s last
     /// hash computation. The child's hash is not stored since it has not yet
     /// been recomputed. The child's `Tree` instance is stored in the link.
-    #[rustfmt::skip]
     Modified {
         pending_writes: usize, // TODO: rename to `pending_hashes`
         child_heights: (u8, u8),
-        tree: Tree
+        tree: Tree,
     },
 
     // Represents a tree node which has been modified since the `Tree`'s last
@@ -261,6 +260,25 @@ impl Link {
             hash: Default::default(),
             child_heights: (0, 0),
         }
+    }
+
+    pub(crate) fn decode_v0<R: Read>(mut input: R) -> Result<Self> {
+        let length = read_u8(&mut input)? as usize;
+
+        let mut key = vec![0; length];
+        input.read_exact(&mut key)?;
+
+        let mut hash = [0; 32];
+        input.read_exact(&mut hash)?;
+
+        let left_height = read_u8(&mut input)?;
+        let right_height = read_u8(input)?;
+
+        Ok(Link::Reference {
+            key,
+            hash,
+            child_heights: (left_height, right_height),
+        })
     }
 }
 


### PR DESCRIPTION
This PR makes so Merk stores track their format version in the internal column family, and migrates from the V0 format (`u8` key lengths) to V1 (`u16` key lengths) when opening.